### PR TITLE
Added .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/runtime/Java/target/
+/tool/target/
+/antlr3-maven-plugin/target/
+/gunit/target/
+/gunit-maven-plugin/target/
+/antlr3-maven-archetype/target/


### PR DESCRIPTION
Currently set to ignore the target folders generated during a maven build. Rebased on antlr/master this time (replaces #2).
