### PR TITLE
Fix failing completejar build due to incorrect use of useProjectArtifact.

### DIFF
--- a/antlrjar.xml
+++ b/antlrjar.xml
@@ -14,11 +14,15 @@
       -->
     <id>completejar</id>
 
-    <!--
-        Exclude the antlr-master pom from the jar - we don't need it
-        and it causes silly things to happen.
-      -->
-    <useProjectArtifact>false</useProjectArtifact>
+    <dependencySets>
+        <dependencySet>
+            <!--
+                Exclude the antlr-master pom from the jar - we don't need it
+                and it causes silly things to happen.
+              -->
+            <useProjectArtifact>false</useProjectArtifact>
+        </dependencySet>
+    </dependencySets>
 
     <!--
         The only output format we need is the executable jar file


### PR DESCRIPTION
(This bug was reported over two years ago, but apparently never fixed, I just got hit by it:
http://www.antlr.org/pipermail/antlr-interest/2009-December/036969.html)

This element is not valid at the place of descriptor XML where it was used, so
maven build fails. Put it under <dependencySet> as documented for assembly
plugin >= 2.2.
