### PR TITLE
Allow grammar files in the root directory in Antlr3Mojo.

### DIFF
--- a/antlr3-maven-plugin/src/main/java/org/antlr/mojo/antlr3/Antlr3Mojo.java
+++ b/antlr3-maven-plugin/src/main/java/org/antlr/mojo/antlr3/Antlr3Mojo.java
@@ -489,6 +489,10 @@ public class Antlr3Mojo
 
         File unprefixedGrammarFileName = new File(grammarFileName.substring(srcPath.length()));
 
-        return unprefixedGrammarFileName.getParent() + File.separator;
+        if (unprefixedGrammarFileName.getParent() != null) {
+            return unprefixedGrammarFileName.getParent() + File.separator;
+        } else {
+            return "";
+        }
     }
 }


### PR DESCRIPTION
Check that the grammar filename has a parent directory. Otherwise,
use the empty string to prevent looking for 'null/MyGrammar.g'.
