### PR TITLE
Don't specify a repository in the pom.

### DIFF
--- a/antlr3-maven-plugin/pom.xml
+++ b/antlr3-maven-plugin/pom.xml
@@ -183,34 +183,6 @@ Jim Idle - March 2009
         </site>
     </distributionManagement>
 
-    <!--
-
-    Inform Maven of the ANTLR snapshot repository, which it will
-    need to consult to get the latest snapshot build of the runtime and tool
-    if it was not built and installed locally.
-    -->
-    <repositories>
-
-      <!--
-        This is the ANTLR repository.
-        -->
-        <repository>
-            <id>antlr-snapshot</id>
-            <name>ANTLR Testing Snapshot Repository</name>
-            <url>http://antlr.org/antlr-snapshot</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </snapshots>
-
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            
-        </repository>
-
-    </repositories>
-    
     <!-- Ancilliary information for completeness
       -->
     <inceptionYear>2009</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -68,29 +68,6 @@
 
   <!--
 
-    Inform Maven of the ANTLR snapshot repository, which it will
-    need to consult to get the latest snapshot build of the runtime
-    if it was not built and installed locally.
-    -->
-    <repositories>
-
-      <!--
-        This is the ANTLR repository.
-        -->
-        <repository>
-            <id>antlr-snapshot</id>
-            <name>ANTLR Testing Snapshot Repository</name>
-            <url>http://antlr.org/antlr-snapshot</url>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </snapshots>
-        </repository>
-
-    </repositories>
-
-  <!--
-
     Tell Maven which other artifacts we need in order to
     build, run and test the ANTLR jars.
     This is the master pom, and so it only contains those


### PR DESCRIPTION
Following the advice in:
http://www.sonatype.com/people/2009/02/why-putting-repositories-in-your-poms-is-a-bad-idea/

This means I can install a -SNAPSHOT build locally without Maven checking the upstream snapshot repository on every run. Remove the repository settings, so developers can either add the repo to settings, install their own build or get it through Central.
