### PR TITLE
Add compiled Python files to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ target/
 # NetBeans user configuration
 nbactions.xml
 nb-configuration.xml
+
+# Python runtime files
+*.py[co]


### PR DESCRIPTION
These files are created in `runtime/Python/antlr3` anytime the code is executed.

_(I signed contributor agreement earlier this year.)_
