### PR TITLE
Java template adaption

### DIFF
--- a/tool/src/main/resources/org/antlr/codegen/templates/Java/Java.stg
+++ b/tool/src/main/resources/org/antlr/codegen/templates/Java/Java.stg
@@ -1115,20 +1115,14 @@ protected class DFA<dfa.decisionNumber> extends DFA {
 <if(dfa.specialStateSTs)>
 	@Override
 	public int specialStateTransition(int s, IntStream _input) throws NoViableAltException {
-		<if(LEXER)>
-		IntStream input = _input;
-		<endif>
-		<if(PARSER)>
-		TokenStream input = (TokenStream)_input;
-		<endif>
-		<if(TREE_PARSER)>
-		TreeNodeStream input = (TreeNodeStream)_input;
-		<endif>
 		int _s = s;
 		switch ( s ) {
 		<dfa.specialStateSTs:{state |
 		case <i0> : <! compressed special state numbers 0..n-1 !>
-			<state>}; separator="\n">
+			s = specialState<i0>(s, input);
+			if (s >= 0) return s;
+			break;
+		}; separator="\n">
 		}
 <if(backtracking)>
 		if (state.backtracking>0) {state.failed=true; return -1;}
@@ -1138,6 +1132,20 @@ protected class DFA<dfa.decisionNumber> extends DFA {
 		error(nvae);
 		throw nvae;
 	}
+<dfa.specialStateSTs:{state |
+	private int specialState<i0>(int s, IntStream _input) {
+		<if(LEXER)>
+		IntStream input = _input;
+		<endif>
+		<if(PARSER)>
+		TokenStream input = (TokenStream)_input;
+		<endif>
+		<if(TREE_PARSER)>
+		TreeNodeStream input = (TreeNodeStream)_input;
+		<endif>
+		<state>
+	\}
+}; separator="\n">
 <endif>
 }
 >>
@@ -1156,8 +1164,7 @@ s = -1;
 <if(semPredState)> <! return input cursor to state before we rewound !>
 input.seek(index<decisionNumber>_<stateNumber>);
 <endif>
-if ( s>=0 ) return s;
-break;
+return s;
 >>
 
 /** Just like a fixed DFA edge, test the lookahead and indicate what


### PR DESCRIPTION
When generating big grammars, it might be possible that the function specialStateTransition exceeds the max body length of the java compiler. Therefore it might be more suitable to generate one additional function for every switch-case block of specialStateTransition.
