### PR TITLE
ANTLRReaderStream buffer size and IndexOutOfBoundException 

### DIFF
--- a/runtime/Java/src/main/java/org/antlr/runtime/ANTLRReaderStream.java
+++ b/runtime/Java/src/main/java/org/antlr/runtime/ANTLRReaderStream.java
@@ -65,6 +65,11 @@ public class ANTLRReaderStream extends ANTLRStringStream {
 		if ( readChunkSize<=0 ) {
 			readChunkSize = READ_BUFFER_SIZE;
 		}
+
+        if(size < readChunkSize){
+            size = readChunkSize;
+        }
+
 		// System.out.println("load "+size+" in chunks of "+readChunkSize);
 		try {
 			// alloc initial buffer size.


### PR DESCRIPTION
This pull requests fixes the case where size is smaller than readChunkSize. This avoids an IndexOutOfBoundException
