### PR TITLE
Fix for antlr Cpp runtime bug #173: added const qualifier to ImplTrai…

### DIFF
--- a/tool/src/main/resources/org/antlr/codegen/templates/Cpp/Cpp.stg
+++ b/tool/src/main/resources/org/antlr/codegen/templates/Cpp/Cpp.stg
@@ -1007,7 +1007,7 @@ parser(	grammar,
 		bitsets,
 		ASTLabelType,
 		superClass="Parser",
-		labelType="ImplTraits::CommonTokenType*",
+		labelType="const ImplTraits::CommonTokenType*",
 		members={<actions.parser.members>}
 		) ::= <<
 <beginNamespace(actions)>


### PR DESCRIPTION
…ts::CommonTokenType*