### PR TITLE
Enforce hoisting of semantic predicates over actions

### DIFF
--- a/tool/src/main/java/org/antlr/analysis/NFAToDFAConverter.java
+++ b/tool/src/main/java/org/antlr/analysis/NFAToDFAConverter.java
@@ -595,6 +595,9 @@ public class NFAToDFAConverter {
 						DFAState d,
 						boolean collectPredicates)
 	{
+		boolean forceHoisting = Boolean.parseBoolean((String)dfa.nfa.grammar.getOption("forceHoisting"));
+		collectPredicates = collectPredicates || forceHoisting;
+		
 		if ( debug ){
 			System.out.println("closure at "+p.enclosingRule.name+" state "+p.stateNumber+"|"+
 							   alt+" filling DFA state "+d.stateNumber+" with context "+context

--- a/tool/src/main/java/org/antlr/tool/Grammar.java
+++ b/tool/src/main/java/org/antlr/tool/Grammar.java
@@ -249,6 +249,7 @@ public class Grammar {
 				add("k");
 				add("backtrack");
 				add("memoize");
+				add("forceHoisting");
 				}
 			};
 

--- a/tool/src/main/java/org/antlr/tool/Grammar.java
+++ b/tool/src/main/java/org/antlr/tool/Grammar.java
@@ -262,6 +262,7 @@ public class Grammar {
 				add("k");
 				add("backtrack");
 				add("memoize");
+				add("forceHoisting");
 				}
 			};
 

--- a/tool/src/test/java/org/antlr/test/TestSemanticPredicates.java
+++ b/tool/src/test/java/org/antlr/test/TestSemanticPredicates.java
@@ -171,6 +171,18 @@ public class TestSemanticPredicates extends BaseTest {
 		checkDecision(g, 1, expecting, null,
 					  null, null, null, null, 0, true);
 	}
+	
+	@Test public void testForceHoistingOverActions() throws Exception {
+		Grammar g = new Grammar(
+			"parser grammar P;\n"+
+		    "options {forceHoisting=true;}\n"+
+			"a : {a1} {p1}? A | {a2} {p2}? A ;");
+		String expecting =
+			".s0-A->.s1\n" +
+			".s1-{p1}?->:s2=>1\n" +
+			".s1-{p2}?->:s3=>2\n";
+		checkDecision(g, 1, expecting, null, null, null, null, null, 0, false);
+	}
 
 	/*
 	@Test public void testIncompleteSemanticHoistedContextk2() throws Exception {

--- a/tool/src/test/java/org/antlr/test/TestSemanticPredicates.java
+++ b/tool/src/test/java/org/antlr/test/TestSemanticPredicates.java
@@ -183,6 +183,39 @@ public class TestSemanticPredicates extends BaseTest {
 			".s1-{p2}?->:s3=>2\n";
 		checkDecision(g, 1, expecting, null, null, null, null, null, 0, false);
 	}
+	
+	
+	@Test public void testForceHoistingOverActions2() throws Exception {
+		Grammar g = new Grammar(
+			"parser grammar P;\n"+
+		    "options {forceHoisting=true;}\n"+
+		    "foobar: (foo | bar)+\n;"+
+			"foo: {/*do nothing*/} {p1}? MY;\n"+
+			"bar: MY;\n");
+
+		String expecting =
+			".s0-EOF->:s1=>3\n"+
+			".s0-MY->.s2\n"+
+			".s2-{p1}?->:s3=>1\n"+
+			".s2-{true}?->:s4=>2\n";
+		checkDecision(g, 1, expecting, null, null, null, null, null, 0, false);
+	}
+	
+	@Test public void testForceHoistingOverActions3() throws Exception {
+		Grammar g = new Grammar(
+			"parser grammar P;\n"+
+		    "options {forceHoisting=true;}\n"+
+		    "foobar: {/*do nothing*/}(foo | bar)+\n;"+
+			"foo: {/*do nothing*/} {p1}? MY;\n"+
+			"bar: MY;\n");
+
+		String expecting =
+			".s0-EOF->:s1=>3\n"+
+			".s0-MY->.s2\n"+
+			".s2-{p1}?->:s3=>1\n"+
+			".s2-{true}?->:s4=>2\n";
+		checkDecision(g, 1, expecting, null, null, null, null, null, 0, false);
+	}
 
 	/*
 	@Test public void testIncompleteSemanticHoistedContextk2() throws Exception {


### PR DESCRIPTION
This pull request adds another grammar option to enforce hoisting of semantic predicates over actions. See the following thread for more details: https://groups.google.com/forum/#!topic/antlr-discussion/UrZEt-uaMVA
