### PR TITLE
Update the Python codegen target & tests

### DIFF
--- a/runtime/Python/hudson-build.sh
+++ b/runtime/Python/hudson-build.sh
@@ -24,7 +24,7 @@ cd $WORKSPACE
 
 # stringtemplate3
 if [ ! -f stringtemplate3-$ST_VERSION.tar.gz ]; then
-    wget http://pypi.python.org/packages/source/s/stringtemplate3/stringtemplate3-$ST_VERSION.tar.gz
+    wget https://pypi.python.org/packages/source/s/stringtemplate3/stringtemplate3-$ST_VERSION.tar.gz
 fi
 (cd tmp; tar xzf ../stringtemplate3-$ST_VERSION.tar.gz)
 (cd tmp/stringtemplate3-$ST_VERSION; python setup.py install --install-lib=$WORKSPACE)

--- a/runtime/Python/setup.py
+++ b/runtime/Python/setup.py
@@ -184,7 +184,7 @@ class functest(Command):
         testDir = os.path.join(os.path.dirname(__file__), 'tests')
         if not os.path.isdir(testDir):
             raise DistutilsFileError(
-                "There is not 'tests' directory. Did you fetch the "
+                "There is no 'tests' directory. Did you fetch the "
                 "development version?",
                 )
 
@@ -208,10 +208,7 @@ class functest(Command):
                 ]
 
         classpath.extend([
-            os.path.join(rootDir, 'lib', 'antlr-2.7.7.jar'),
-            os.path.join(rootDir, 'lib', 'stringtemplate-3.2.1.jar'),
-            os.path.join(rootDir, 'lib', 'ST-4.0.2.jar'),
-            os.path.join(rootDir, 'lib', 'junit-4.2.jar')
+            os.path.join(rootDir, 'antlr-complete', 'target', 'antlr-complete-3.5.3-SNAPSHOT.jar'),
             ])
         os.environ['CLASSPATH'] = ':'.join(classpath)
 

--- a/runtime/Python/tests/t001lexer.py
+++ b/runtime/Python/tests/t001lexer.py
@@ -25,10 +25,10 @@ class t001lexer(testbase.ANTLRTest):
         lexer = self.getLexer(stream)
 
         token = lexer.nextToken()
-        self.failUnlessEqual(token.type, self.lexerModule.ZERO)
+        self.assertEqual(token.type, self.lexerModule.ZERO)
 
         token = lexer.nextToken()
-        self.failUnlessEqual(token.type, self.lexerModule.EOF)
+        self.assertEqual(token.type, self.lexerModule.EOF)
         
 
     def testIteratorInterface(self):
@@ -37,7 +37,7 @@ class t001lexer(testbase.ANTLRTest):
 
         types = [token.type for token in lexer]
 
-        self.failUnlessEqual(types, [self.lexerModule.ZERO])
+        self.assertListEqual(types, [self.lexerModule.ZERO])
         
 
     def testMalformedInput(self):
@@ -49,8 +49,8 @@ class t001lexer(testbase.ANTLRTest):
             self.fail()
 
         except antlr3.MismatchedTokenException, exc:
-            self.failUnlessEqual(exc.expecting, '0')
-            self.failUnlessEqual(exc.unexpectedType, '1')
+            self.assertEqual(exc.expecting, '0')
+            self.assertEqual(exc.unexpectedType, '1')
             
 
 if __name__ == '__main__':

--- a/runtime/Python/tests/t002lexer.py
+++ b/runtime/Python/tests/t002lexer.py
@@ -25,13 +25,13 @@ class t002lexer(testbase.ANTLRTest):
         lexer = self.getLexer(stream)
 
         token = lexer.nextToken()
-        self.failUnlessEqual(token.type, self.lexerModule.ZERO)
+        self.assertEqual(token.type, self.lexerModule.ZERO)
 
         token = lexer.nextToken()
-        self.failUnlessEqual(token.type, self.lexerModule.ONE)
+        self.assertEqual(token.type, self.lexerModule.ONE)
 
         token = lexer.nextToken()
-        self.failUnlessEqual(token.type, self.lexerModule.EOF)
+        self.assertEqual(token.type, self.lexerModule.EOF)
         
 
     def testMalformedInput(self):
@@ -43,7 +43,7 @@ class t002lexer(testbase.ANTLRTest):
             self.fail()
 
         except antlr3.NoViableAltException, exc:
-            self.failUnlessEqual(exc.unexpectedType, '2')
+            self.assertEqual(exc.unexpectedType, '2')
             
 
 if __name__ == '__main__':

--- a/runtime/Python/tests/t003lexer.py
+++ b/runtime/Python/tests/t003lexer.py
@@ -25,16 +25,16 @@ class t003lexer(testbase.ANTLRTest):
         lexer = self.getLexer(stream)
 
         token = lexer.nextToken()
-        self.failUnlessEqual(token.type, self.lexerModule.ZERO)
+        self.assertEqual(token.type, self.lexerModule.ZERO)
 
         token = lexer.nextToken()
-        self.failUnlessEqual(token.type, self.lexerModule.FOOZE)
+        self.assertEqual(token.type, self.lexerModule.FOOZE)
 
         token = lexer.nextToken()
-        self.failUnlessEqual(token.type, self.lexerModule.ONE)
+        self.assertEqual(token.type, self.lexerModule.ONE)
 
         token = lexer.nextToken()
-        self.failUnlessEqual(token.type, self.lexerModule.EOF)
+        self.assertEqual(token.type, self.lexerModule.EOF)
         
 
     def testMalformedInput(self):
@@ -46,7 +46,7 @@ class t003lexer(testbase.ANTLRTest):
             self.fail()
 
         except antlr3.NoViableAltException, exc:
-            self.failUnlessEqual(exc.unexpectedType, '2')
+            self.assertEqual(exc.unexpectedType, '2')
             
 
 if __name__ == '__main__':

--- a/runtime/Python/tests/t004lexer.py
+++ b/runtime/Python/tests/t004lexer.py
@@ -61,8 +61,8 @@ class t004lexer(testbase.ANTLRTest):
             self.fail()
 
         except antlr3.MismatchedTokenException, exc:
-            self.failUnlessEqual(exc.expecting, 'f')
-            self.failUnlessEqual(exc.unexpectedType, '2')
+            self.assertEqual(exc.expecting, 'f')
+            self.assertEqual(exc.unexpectedType, '2')
             
 
 if __name__ == '__main__':

--- a/runtime/Python/tests/t022scopes.py
+++ b/runtime/Python/tests/t022scopes.py
@@ -66,7 +66,7 @@ class t022scopes(testbase.ANTLRTest):
         parser = self.getParser(tStream)
         symbols = parser.c()
 
-        self.failUnlessEqual(
+        self.assertEqual(
             symbols,
             set(['i', 'j'])
             )
@@ -91,7 +91,7 @@ class t022scopes(testbase.ANTLRTest):
             parser.c()
             self.fail()
         except RuntimeError, exc:
-            self.failUnlessEqual(exc.args[0], 'x')
+            self.assertEqual(exc.args[0], 'x')
 
 
     def testd1(self):
@@ -114,7 +114,7 @@ class t022scopes(testbase.ANTLRTest):
         parser = self.getParser(tStream)
         symbols = parser.d()
 
-        self.failUnlessEqual(
+        self.assertEqual(
             symbols,
             set(['i', 'j'])
             )
@@ -131,7 +131,7 @@ class t022scopes(testbase.ANTLRTest):
         parser = self.getParser(tStream)
         res = parser.e()
 
-        self.failUnlessEqual(res, 12)
+        self.assertEqual(res, 12)
 
 
     def testf1(self):
@@ -145,7 +145,7 @@ class t022scopes(testbase.ANTLRTest):
         parser = self.getParser(tStream)
         res = parser.f()
 
-        self.failUnlessEqual(res, None)
+        self.assertEqual(res, None)
 
 
     def testf2(self):
@@ -159,7 +159,7 @@ class t022scopes(testbase.ANTLRTest):
         parser = self.getParser(tStream)
         res = parser.f()
 
-        self.failUnlessEqual(res, None)
+        self.assertEqual(res, None)
 
 
 

--- a/runtime/Python/tests/t033backtracking.py
+++ b/runtime/Python/tests/t033backtracking.py
@@ -17,7 +17,6 @@ class t033backtracking(testbase.ANTLRTest):
         return TParser
 
 
-    @testbase.broken("Some bug in the tool", SyntaxError)
     def testValid1(self):
         cStream = antlr3.StringStream('int a;')
 

--- a/runtime/Python/tests/t042ast.py
+++ b/runtime/Python/tests/t042ast.py
@@ -38,7 +38,7 @@ class t042ast(testbase.ANTLRTest):
     
     def testR1(self):
         r = self.parse("1 + 2", 'r1')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(+ 1 2)'
             )
@@ -46,7 +46,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR2a(self):
         r = self.parse("assert 2+3;", 'r2')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(assert (+ 2 3))'
             )
@@ -54,7 +54,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR2b(self):
         r = self.parse("assert 2+3 : 5;", 'r2')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(assert (+ 2 3) 5)'
             )
@@ -62,7 +62,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR3a(self):
         r = self.parse("if 1 fooze", 'r3')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(if 1 fooze)'
             )
@@ -70,7 +70,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR3b(self):
         r = self.parse("if 1 fooze else fooze", 'r3')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(if 1 fooze fooze)'
             )
@@ -78,7 +78,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR4a(self):
         r = self.parse("while 2 fooze", 'r4')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(while 2 fooze)'
             )
@@ -86,7 +86,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR5a(self):
         r = self.parse("return;", 'r5')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'return'
             )
@@ -94,7 +94,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR5b(self):
         r = self.parse("return 2+3;", 'r5')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(return (+ 2 3))'
             )
@@ -102,7 +102,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR6a(self):
         r = self.parse("3", 'r6')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '3'
             )
@@ -110,7 +110,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR6b(self):
         r = self.parse("3 a", 'r6')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '3 a'
             )
@@ -118,14 +118,14 @@ class t042ast(testbase.ANTLRTest):
 
     def testR7(self):
         r = self.parse("3", 'r7')
-        self.failUnless(
+        self.assertTrue(
             r.tree is None
             )
 
 
     def testR8(self):
         r = self.parse("var foo:bool", 'r8')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(var bool foo)'
             )
@@ -133,7 +133,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR9(self):
         r = self.parse("int foo;", 'r9')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(VARDEF int foo)'
             )
@@ -141,7 +141,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR10(self):
         r = self.parse("10", 'r10')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '10.0'
             )
@@ -149,7 +149,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR11a(self):
         r = self.parse("1+2", 'r11')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(EXPR (+ 1 2))'
             )
@@ -157,7 +157,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR11b(self):
         r = self.parse("", 'r11')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'EXPR'
             )
@@ -165,7 +165,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR12a(self):
         r = self.parse("foo", 'r12')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'foo'
             )
@@ -173,7 +173,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR12b(self):
         r = self.parse("foo, bar, gnurz", 'r12')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'foo bar gnurz'
             )
@@ -181,7 +181,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR13a(self):
         r = self.parse("int foo;", 'r13')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(int foo)'
             )
@@ -189,7 +189,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR13b(self):
         r = self.parse("bool foo, bar, gnurz;", 'r13')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(bool foo bar gnurz)'
             )
@@ -197,7 +197,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR14a(self):
         r = self.parse("1+2 int", 'r14')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(EXPR (+ 1 2) int)'
             )
@@ -205,7 +205,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR14b(self):
         r = self.parse("1+2 int bool", 'r14')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(EXPR (+ 1 2) int bool)'
             )
@@ -213,7 +213,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR14c(self):
         r = self.parse("int bool", 'r14')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(EXPR int bool)'
             )
@@ -221,7 +221,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR14d(self):
         r = self.parse("fooze fooze int bool", 'r14')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(EXPR fooze fooze int bool)'
             )
@@ -229,7 +229,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR14e(self):
         r = self.parse("7+9 fooze fooze int bool", 'r14')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(EXPR (+ 7 9) fooze fooze int bool)'
             )
@@ -237,7 +237,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR15(self):
         r = self.parse("7", 'r15')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '7 7'
             )
@@ -245,7 +245,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR16a(self):
         r = self.parse("int foo", 'r16')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(int foo)'
             )
@@ -254,7 +254,7 @@ class t042ast(testbase.ANTLRTest):
     def testR16b(self):
         r = self.parse("int foo, bar, gnurz", 'r16')
             
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(int foo) (int bar) (int gnurz)'
             )
@@ -262,7 +262,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR17a(self):
         r = self.parse("for ( fooze ; 1 + 2 ; fooze ) fooze", 'r17')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(for fooze (+ 1 2) fooze fooze)'
             )
@@ -270,7 +270,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR18a(self):
         r = self.parse("for", 'r18')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'BLOCK'
             )
@@ -278,7 +278,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR19a(self):
         r = self.parse("for", 'r19')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'for'
             )
@@ -286,7 +286,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR20a(self):
         r = self.parse("for", 'r20')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'FOR'
             )
@@ -294,7 +294,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR21a(self):
         r = self.parse("for", 'r21')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'BLOCK'
             )
@@ -302,7 +302,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR22a(self):
         r = self.parse("for", 'r22')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'for'
             )
@@ -310,7 +310,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR23a(self):
         r = self.parse("for", 'r23')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'FOR'
             )
@@ -318,7 +318,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR24a(self):
         r = self.parse("fooze 1 + 2", 'r24')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(fooze (+ 1 2))'
             )
@@ -326,7 +326,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR25a(self):
         r = self.parse("fooze, fooze2 1 + 2", 'r25')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(fooze (+ 1 2))'
             )
@@ -334,7 +334,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR26a(self):
         r = self.parse("fooze, fooze2", 'r26')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(BLOCK fooze fooze2)'
             )
@@ -342,7 +342,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR27a(self):
         r = self.parse("fooze 1 + 2", 'r27')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(fooze (fooze (+ 1 2)))'
             )
@@ -350,7 +350,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR28(self):
         r = self.parse("foo28a", 'r28')
-        self.failUnless(
+        self.assertTrue(
             r.tree is None
             )
 
@@ -374,7 +374,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR31a(self):
         r = self.parse("public int gnurz = 1 + 2;", 'r31', flag=0)
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(VARDEF gnurz public int (+ 1 2))'
             )
@@ -382,7 +382,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR31b(self):
         r = self.parse("public int gnurz = 1 + 2;", 'r31', flag=1)
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(VARIABLE gnurz public int (+ 1 2))'
             )
@@ -390,7 +390,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR31c(self):
         r = self.parse("public int gnurz = 1 + 2;", 'r31', flag=2)
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(FIELD gnurz public int (+ 1 2))'
             )
@@ -398,7 +398,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR32a(self):
         r = self.parse("gnurz 32", 'r32', [1], flag=2)
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'gnurz'
             )
@@ -406,7 +406,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR32b(self):
         r = self.parse("gnurz 32", 'r32', [2], flag=2)
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '32'
             )
@@ -414,14 +414,14 @@ class t042ast(testbase.ANTLRTest):
 
     def testR32c(self):
         r = self.parse("gnurz 32", 'r32', [3], flag=2)
-        self.failUnless(
+        self.assertTrue(
             r.tree is None
             )
 
 
     def testR33a(self):
         r = self.parse("public private fooze", 'r33')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'fooze'
             )
@@ -429,7 +429,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR34a(self):
         r = self.parse("public class gnurz { fooze fooze2 }", 'r34')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(class gnurz public fooze fooze2)'
             )
@@ -437,7 +437,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR34b(self):
         r = self.parse("public class gnurz extends bool implements int, bool { fooze fooze2 }", 'r34')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(class gnurz public (extends bool) (implements int bool) fooze fooze2)'
             )
@@ -454,7 +454,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR36a(self):
         r = self.parse("if ( 1 + 2 ) fooze", 'r36')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(if (EXPR (+ 1 2)) fooze)'
             )
@@ -462,7 +462,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR36b(self):
         r = self.parse("if ( 1 + 2 ) fooze else fooze2", 'r36')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(if (EXPR (+ 1 2)) fooze fooze2)'
             )
@@ -470,7 +470,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR37(self):
         r = self.parse("1 + 2 + 3", 'r37')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(+ (+ 1 2) 3)'
             )
@@ -478,7 +478,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR38(self):
         r = self.parse("1 + 2 + 3", 'r38')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(+ (+ 1 2) 3)'
             )
@@ -486,7 +486,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR39a(self):
         r = self.parse("gnurz[1]", 'r39')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(INDEX gnurz 1)'
             )
@@ -494,7 +494,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR39b(self):
         r = self.parse("gnurz(2)", 'r39')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(CALL gnurz 2)'
             )
@@ -502,7 +502,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR39c(self):
         r = self.parse("gnurz.gnarz", 'r39')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(FIELDACCESS gnurz gnarz)'
             )
@@ -510,7 +510,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR39d(self):
         r = self.parse("gnurz.gnarz.gnorz", 'r39')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(FIELDACCESS (FIELDACCESS gnurz gnarz) gnorz)'
             )
@@ -518,7 +518,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR40(self):
         r = self.parse("1 + 2 + 3;", 'r40')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(+ 1 2 3)'
             )
@@ -526,7 +526,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR41(self):
         r = self.parse("1 + 2 + 3;", 'r41')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(3 (2 1))'
             )
@@ -534,7 +534,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR42(self):
         r = self.parse("gnurz, gnarz, gnorz", 'r42')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'gnurz gnarz gnorz'
             )
@@ -542,10 +542,10 @@ class t042ast(testbase.ANTLRTest):
 
     def testR43(self):
         r = self.parse("gnurz, gnarz, gnorz", 'r43')
-        self.failUnless(
+        self.assertTrue(
             r.tree is None
             )
-        self.failUnlessEqual(
+        self.assertListEqual(
             r.res,
             ['gnurz', 'gnarz', 'gnorz']
             )
@@ -553,7 +553,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR44(self):
         r = self.parse("gnurz, gnarz, gnorz", 'r44')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(gnorz (gnarz gnurz))'
             )
@@ -561,7 +561,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR45(self):
         r = self.parse("gnurz", 'r45')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'gnurz'
             )
@@ -569,10 +569,10 @@ class t042ast(testbase.ANTLRTest):
 
     def testR46(self):
         r = self.parse("gnurz, gnarz, gnorz", 'r46')
-        self.failUnless(
+        self.assertTrue(
             r.tree is None
             )
-        self.failUnlessEqual(
+        self.assertListEqual(
             r.res,
             ['gnurz', 'gnarz', 'gnorz']
             )
@@ -580,7 +580,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR47(self):
         r = self.parse("gnurz, gnarz, gnorz", 'r47')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'gnurz gnarz gnorz'
             )
@@ -588,7 +588,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR48(self):
         r = self.parse("gnurz, gnarz, gnorz", 'r48')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'gnurz gnarz gnorz'
             )
@@ -596,7 +596,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR49(self):
         r = self.parse("gnurz gnorz", 'r49')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(gnurz gnorz)'
             )
@@ -604,7 +604,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR50(self):
         r = self.parse("gnurz", 'r50')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(1.0 gnurz)'
             )
@@ -612,7 +612,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR51(self):
         r = self.parse("gnurza gnurzb gnurzc", 'r51')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.res.toStringTree(),
             'gnurzb'
             )
@@ -620,7 +620,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR52(self):
         r = self.parse("gnurz", 'r52')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.res.toStringTree(),
             'gnurz'
             )
@@ -628,7 +628,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR53(self):
         r = self.parse("gnurz", 'r53')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.res.toStringTree(),
             'gnurz'
             )
@@ -636,7 +636,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR54(self):
         r = self.parse("gnurza 1 + 2 gnurzb", 'r54')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(+ 1 2)'
             )
@@ -644,7 +644,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR55a(self):
         r = self.parse("public private 1 + 2", 'r55')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'public private (+ 1 2)'
             )
@@ -652,7 +652,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR55b(self):
         r = self.parse("public fooze", 'r55')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'public fooze'
             )
@@ -660,7 +660,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR56(self):
         r = self.parse("a b c d", 'r56')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'foo'
             )
@@ -668,7 +668,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR57(self):
         r = self.parse("a b c d", 'r57')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             'foo'
             )
@@ -676,7 +676,7 @@ class t042ast(testbase.ANTLRTest):
 
     def testR59(self):
         r = self.parse("a b c fooze", 'r59')
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             '(a fooze) (b fooze) (c fooze)'
             )

--- a/runtime/Python/tests/t044trace.py
+++ b/runtime/Python/tests/t044trace.py
@@ -64,7 +64,7 @@ class T(testbase.ANTLRTest):
         parser = self.getParser(tStream)
         parser.a()
 
-        self.failUnlessEqual(
+        self.assertListEqual(
             lexer.traces,
             [ '>T__7', '<T__7', '>WS', '<WS', '>INT', '<INT', '>WS', '<WS',
               '>T__6', '<T__6', '>WS', '<WS', '>INT', '<INT', '>WS', '<WS',
@@ -72,7 +72,7 @@ class T(testbase.ANTLRTest):
               '>T__8', '<T__8']
             )
 
-        self.failUnlessEqual(
+        self.assertListEqual(
             parser.traces,
             [ '>a', '>synpred1_t044trace_fragment', '<synpred1_t044trace_fragment', '>b', '>c',
               '<c', '>c', '<c', '>c', '<c', '<b', '<a' ]
@@ -86,7 +86,7 @@ class T(testbase.ANTLRTest):
         parser = self.getParser(tStream)
         parser.a()
 
-        self.failUnlessEqual(
+        self.assertListEqual(
             parser._stack,
             ['a', 'b', 'c']
             )

--- a/runtime/Python/tests/t046rewrite.py
+++ b/runtime/Python/tests/t046rewrite.py
@@ -44,7 +44,7 @@ class T(testbase.ANTLRTest):
 
         ''')
 
-        self.failUnlessEqual(
+        self.assertEqual(
             str(tStream),
             expectedOutput
             )

--- a/runtime/Python/tests/t047treeparser.py
+++ b/runtime/Python/tests/t047treeparser.py
@@ -56,7 +56,7 @@ class T(testbase.ANTLRTest):
         parser = self.getParser(tStream)
         r = parser.program()
 
-        self.failUnlessEqual(
+        self.assertEqual(
             r.tree.toStringTree(),
             "(VAR_DEF char c) (VAR_DEF int x) (FUNC_DECL (FUNC_HDR void bar (ARG_DEF int x))) (FUNC_DEF (FUNC_HDR int foo (ARG_DEF int y) (ARG_DEF char d)) (BLOCK (VAR_DEF int i) (for (= i 0) (< i 3) (= i (+ i 1)) (BLOCK (= x 3) (= y 5)))))"
             )
@@ -69,7 +69,7 @@ class T(testbase.ANTLRTest):
         # FIXME: need to crosscheck with Java target (compile walker with
         # -trace option), if this is the real list. For now I'm happy that
         # it does not crash ;)
-        self.failUnlessEqual(
+        self.assertListEqual(
             walker.traces,
             [ '>program', '>declaration', '>variable', '>type', '<type',
               '>declarator', '<declarator', '<variable', '<declaration',
@@ -115,7 +115,7 @@ class T(testbase.ANTLRTest):
         walker = self.getWalker(nodes)
         r = walker.variable()
 
-        self.failUnlessEqual(r, 'c')
+        self.assertEqual(r, 'c')
         
 
 if __name__ == '__main__':

--- a/runtime/Python/tests/t048rewrite.py
+++ b/runtime/Python/tests/t048rewrite.py
@@ -27,7 +27,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "0abc"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def testInsertAfterLastIndex(self):
@@ -36,7 +36,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "abcx"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def test2InsertBeforeAfterMiddleIndex(self):
@@ -46,7 +46,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "axbxc"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def testReplaceIndex0(self):
@@ -55,7 +55,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "xbc"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def testReplaceLastIndex(self):
@@ -64,7 +64,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "abx"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def testReplaceMiddleIndex(self):
@@ -73,7 +73,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "axc"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def test2ReplaceMiddleIndex(self):
@@ -83,7 +83,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "ayc"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def test2ReplaceMiddleIndex1InsertBefore(self):
@@ -94,7 +94,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "_ayc"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
 
     def testReplaceThenDeleteMiddleIndex(self):
@@ -104,7 +104,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "ac"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def testInsertInPriorReplace(self):
@@ -115,7 +115,7 @@ class T1(testbase.ANTLRTest):
             tokens.toString()
             self.fail()
         except ValueError, exc:
-            self.failUnlessEqual(
+            self.assertEqual(
                 str(exc),
                 "insert op <InsertBeforeOp@1:\"0\"> within boundaries of "
                 "previous <ReplaceOp@0..2:\"x\">"
@@ -128,7 +128,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "0xbc"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def test2InsertMiddleIndex(self):
@@ -138,7 +138,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "ayxbc"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def test2InsertThenReplaceIndex0(self):
@@ -149,7 +149,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "yxzbc"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def testReplaceThenInsertBeforeLastIndex(self):
@@ -159,7 +159,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "abyx"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def testInsertThenReplaceLastIndex(self):
@@ -169,7 +169,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "abyx"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def testReplaceThenInsertAfterLastIndex(self):
@@ -179,7 +179,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "abxy"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def testReplaceRangeThenInsertAtLeftEdge(self):
@@ -189,7 +189,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "abyxba"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def testReplaceRangeThenInsertAtRightEdge(self):
@@ -201,7 +201,7 @@ class T1(testbase.ANTLRTest):
             tokens.toString()
             self.fail()
         except ValueError, exc:
-            self.failUnlessEqual(
+            self.assertEqual(
                 str(exc),
                 "insert op <InsertBeforeOp@4:\"y\"> within boundaries of "
                 "previous <ReplaceOp@2..4:\"x\">")
@@ -214,7 +214,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "abxyba"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def testReplaceAll(self):
@@ -223,7 +223,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "x"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def testReplaceSubsetThenFetch(self):
@@ -232,7 +232,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString(0, 6)
         expecting = "abxyzba"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def testReplaceThenReplaceSuperset(self):
@@ -244,7 +244,7 @@ class T1(testbase.ANTLRTest):
             tokens.toString()
             self.fail()
         except ValueError, exc:
-            self.failUnlessEqual(
+            self.assertEqual(
                 str(exc),
                 "replace op boundaries of <ReplaceOp@3..5:\"foo\"> overlap "
                 "with previous <ReplaceOp@2..4:\"xyz\">")
@@ -259,7 +259,7 @@ class T1(testbase.ANTLRTest):
             tokens.toString()
             self.fail()
         except ValueError, exc:
-            self.failUnlessEqual(
+            self.assertEqual(
                 str(exc),
                 "replace op boundaries of <ReplaceOp@1..3:\"foo\"> overlap "
                 "with previous <ReplaceOp@2..4:\"xyz\">")
@@ -272,7 +272,7 @@ class T1(testbase.ANTLRTest):
 
         result = tokens.toString()
         expecting = "fooa"
-        self.failUnlessEqual(result, expecting)
+        self.assertEqual(result, expecting)
 
 
     def testCombineInserts(self):
@@ -281,7 +281,7 @@ class T1(testbase.ANTLRTest):
         tokens.insertBefore(0, "y")
         result = tokens.toString()
         expecting = "yxabc"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
 
     def testCombine3Inserts(self):
@@ -291,7 +291,7 @@ class T1(testbase.ANTLRTest):
         tokens.insertBefore(1, "z")
         result = tokens.toString()
         expecting = "yazxbc"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
 
     def testCombineInsertOnLeftWithReplace(self):
@@ -300,7 +300,7 @@ class T1(testbase.ANTLRTest):
         tokens.insertBefore(0, "z") # combine with left edge of rewrite
         result = tokens.toString()
         expecting = "zfoo"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
 
     def testCombineInsertOnLeftWithDelete(self):
@@ -309,7 +309,7 @@ class T1(testbase.ANTLRTest):
         tokens.insertBefore(0, "z") # combine with left edge of rewrite
         result = tokens.toString()
         expecting = "z" # make sure combo is not znull
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
 
     def testDisjointInserts(self):
@@ -319,7 +319,7 @@ class T1(testbase.ANTLRTest):
         tokens.insertBefore(0, "z")
         result = tokens.toString()
         expecting = "zaxbyc"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
 
     def testOverlappingReplace(self):
@@ -328,7 +328,7 @@ class T1(testbase.ANTLRTest):
         tokens.replace(0, 3, "bar") # wipes prior nested replace
         result = tokens.toString()
         expecting = "bar"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
 
     def testOverlappingReplace2(self):
@@ -340,7 +340,7 @@ class T1(testbase.ANTLRTest):
             tokens.toString()
             self.fail()
         except ValueError, exc:
-            self.failUnlessEqual(
+            self.assertEqual(
                 str(exc),
                 "replace op boundaries of <ReplaceOp@1..2:\"foo\"> overlap "
                 "with previous <ReplaceOp@0..3:\"bar\">")
@@ -352,7 +352,7 @@ class T1(testbase.ANTLRTest):
         tokens.replace(0, 2, "bar") # wipes prior nested replace
         result = tokens.toString()
         expecting = "barc"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
 
     def testOverlappingReplace4(self):
@@ -361,7 +361,7 @@ class T1(testbase.ANTLRTest):
         tokens.replace(1, 3, "bar") # wipes prior nested replace
         result = tokens.toString()
         expecting = "abar"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
 
     def testDropIdenticalReplace(self):
@@ -370,7 +370,7 @@ class T1(testbase.ANTLRTest):
         tokens.replace(1, 2, "foo") # drop previous, identical
         result = tokens.toString()
         expecting = "afooc"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
 
     def testDropPrevCoveredInsert(self):
@@ -379,7 +379,7 @@ class T1(testbase.ANTLRTest):
         tokens.replace(1, 2, "foo") # kill prev insert
         result = tokens.toString()
         expecting = "afoofoo"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
 
     def testLeaveAloneDisjointInsert(self):
@@ -388,7 +388,7 @@ class T1(testbase.ANTLRTest):
         tokens.replace(2, 3, "foo")
         result = tokens.toString()
         expecting = "axbfoo"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
 
     def testLeaveAloneDisjointInsert2(self):
@@ -397,7 +397,7 @@ class T1(testbase.ANTLRTest):
         tokens.insertBefore(1, "x")
         result = tokens.toString()
         expecting = "axbfoo"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
 
     def testInsertBeforeTokenThenDeleteThatToken(self):
@@ -406,7 +406,7 @@ class T1(testbase.ANTLRTest):
         tokens.delete(2)
         result = tokens.toString()
         expecting = "aby"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
 
 class T2(testbase.ANTLRTest):
@@ -431,19 +431,19 @@ class T2(testbase.ANTLRTest):
 
         result = tokens.toOriginalString()
         expecting = "x = 3 * 0;"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
         result = tokens.toString()
         expecting = "x = 0;"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
         result = tokens.toString(0, 9)
         expecting = "x = 0;"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
         result = tokens.toString(4, 8)
         expecting = "0"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
 
     def testToStringStartStop2(self):
@@ -453,37 +453,37 @@ class T2(testbase.ANTLRTest):
 
         result = tokens.toOriginalString()
         expecting = "x = 3 * 0 + 2 * 0;"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
         tokens.replace(4, 8, "0") # replace 3 * 0 with 0
         result = tokens.toString()
         expecting = "x = 0 + 2 * 0;"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
         result = tokens.toString(0, 17)
         expecting = "x = 0 + 2 * 0;"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
         result = tokens.toString(4, 8)
         expecting = "0"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
         result = tokens.toString(0, 8)
         expecting = "x = 0"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
         result = tokens.toString(12, 16)
         expecting = "2 * 0"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
         tokens.insertAfter(17, "// comment")
         result = tokens.toString(12, 18)
         expecting = "2 * 0;// comment"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
         result = tokens.toString(0, 8) # try again after insert at end
         expecting = "x = 0"
-        self.failUnlessEqual(expecting, result)
+        self.assertEqual(expecting, result)
 
 
 if __name__ == '__main__':

--- a/runtime/Python/tests/t049treeparser.py
+++ b/runtime/Python/tests/t049treeparser.py
@@ -79,7 +79,7 @@ class T(testbase.ANTLRTest):
             "abc 34"
             )
 
-        self.failUnlessEqual("abc, 34", found)
+        self.assertEqual("abc, 34", found)
         
 
 
@@ -113,7 +113,7 @@ class T(testbase.ANTLRTest):
             "abc 34"
             )
             
-        self.failUnlessEqual("abc, 34", found)
+        self.assertEqual("abc, 34", found)
 
 
     def testFlatVsTreeDecision(self):
@@ -148,7 +148,7 @@ class T(testbase.ANTLRTest):
             treeGrammar, 'a',
             "a 1 b 2"
             )
-        self.failUnlessEqual("^(a 1)b 2\n", found)
+        self.assertEqual("^(a 1)b 2\n", found)
 
 
     def testFlatVsTreeDecision2(self):
@@ -183,7 +183,7 @@ class T(testbase.ANTLRTest):
             treeGrammar, 'a',
             "a 1 2 3 b 4 5"
             )
-        self.failUnlessEqual("^(a 3)b 5\n", found)
+        self.assertEqual("^(a 3)b 5\n", found)
 
 
     def testCyclicDFALookahead(self):
@@ -217,7 +217,7 @@ class T(testbase.ANTLRTest):
             treeGrammar, 'a',
             "a 1 2 3."
             )
-        self.failUnlessEqual("alt 1", found)
+        self.assertEqual("alt 1", found)
 
 
 ##     def testTemplateOutput(self):
@@ -271,7 +271,7 @@ class T(testbase.ANTLRTest):
             treeGrammar, 'a',
             "abc"
             )
-        self.failUnlessEqual("abc", found)
+        self.assertEqual("abc", found)
 
 
     def testNullableChildList2(self):
@@ -304,7 +304,7 @@ class T(testbase.ANTLRTest):
             treeGrammar, 'a',
             "abc;"
             )
-        self.failUnlessEqual("abc", found)
+        self.assertEqual("abc", found)
 
 
     def testNullableChildList3(self):
@@ -338,7 +338,7 @@ class T(testbase.ANTLRTest):
             treeGrammar, 'a',
             "abc def;"
             )
-        self.failUnlessEqual("abc, def", found)
+        self.assertEqual("abc, def", found)
 
 
     def testActionsAfterRoot(self):
@@ -371,7 +371,7 @@ class T(testbase.ANTLRTest):
             treeGrammar, 'a',
             "abc;"
             )
-        self.failUnless("abc, 2\n", found)
+        self.assertTrue("abc, 2\n", found)
 
 
     def testWildcardLookahead(self):

--- a/runtime/Python/tests/t051treeRewriteAST.py
+++ b/runtime/Python/tests/t051treeRewriteAST.py
@@ -79,7 +79,7 @@ class T(testbase.ANTLRTest):
             "abc 34"
             )
 
-        self.failUnlessEqual("34 abc", found)
+        self.assertEqual("34 abc", found)
 
 
     def testSimpleTree(self):
@@ -114,7 +114,7 @@ class T(testbase.ANTLRTest):
             "abc 34"
             )
 
-        self.failUnlessEqual("(34 abc)", found)
+        self.assertEqual("(34 abc)", found)
 
 
     def testCombinedRewriteAndAuto(self):
@@ -149,7 +149,7 @@ class T(testbase.ANTLRTest):
             "abc 34"
             )
 
-        self.failUnlessEqual("(34 abc)", found)
+        self.assertEqual("(34 abc)", found)
 
 
         found = self.execTreeParser(
@@ -158,7 +158,7 @@ class T(testbase.ANTLRTest):
             "34"
             )
 
-        self.failUnlessEqual("34", found)
+        self.assertEqual("34", found)
 
 
     def testAvoidDup(self):
@@ -193,7 +193,7 @@ class T(testbase.ANTLRTest):
             "abc"
             )
 
-        self.failUnlessEqual("(abc abc)", found)
+        self.assertEqual("(abc abc)", found)
 
 
     def testLoop(self):
@@ -228,7 +228,7 @@ class T(testbase.ANTLRTest):
             "a b c 3 4 5"
             )
 
-        self.failUnlessEqual("3 4 5 a b c", found)
+        self.assertEqual("3 4 5 a b c", found)
 
 
     def testAutoDup(self):
@@ -263,7 +263,7 @@ class T(testbase.ANTLRTest):
             "abc"
             )
 
-        self.failUnlessEqual("abc", found)
+        self.assertEqual("abc", found)
 
 
     def testAutoDupRule(self):
@@ -300,7 +300,7 @@ class T(testbase.ANTLRTest):
             "a 1"
             )
 
-        self.failUnlessEqual("a 1", found)
+        self.assertEqual("a 1", found)
 
 
     def testAutoWildcard(self):
@@ -468,7 +468,7 @@ class T(testbase.ANTLRTest):
             "a b 3"
             )
 
-        self.failUnlessEqual("a b 3", found)
+        self.assertEqual("a b 3", found)
 
 
     def testAutoDupTree(self):
@@ -504,7 +504,7 @@ class T(testbase.ANTLRTest):
             "a 3"
             )
 
-        self.failUnlessEqual("(a 3)", found)
+        self.assertEqual("(a 3)", found)
 
 
     def testAutoDupTreeWithLabels(self):
@@ -540,7 +540,7 @@ class T(testbase.ANTLRTest):
             "a 3"
             )
 
-        self.failUnlessEqual("(a 3)", found)
+        self.assertEqual("(a 3)", found)
 
 
     def testAutoDupTreeWithListLabels(self):
@@ -576,7 +576,7 @@ class T(testbase.ANTLRTest):
             "a 3"
             )
 
-        self.failUnlessEqual("(a 3)", found)
+        self.assertEqual("(a 3)", found)
 
 
     def testAutoDupTreeWithRuleRoot(self):
@@ -612,7 +612,7 @@ class T(testbase.ANTLRTest):
             "a 3"
             )
 
-        self.failUnlessEqual("(a 3)", found)
+        self.assertEqual("(a 3)", found)
 
 
     def testAutoDupTreeWithRuleRootAndLabels(self):
@@ -648,7 +648,7 @@ class T(testbase.ANTLRTest):
             "a 3"
             )
 
-        self.failUnlessEqual("(a 3)", found)
+        self.assertEqual("(a 3)", found)
 
 
     def testAutoDupTreeWithRuleRootAndListLabels(self):
@@ -685,7 +685,7 @@ class T(testbase.ANTLRTest):
             "a 3"
             )
 
-        self.failUnlessEqual("(a 3)", found)
+        self.assertEqual("(a 3)", found)
 
 
     def testAutoDupNestedTree(self):
@@ -721,7 +721,7 @@ class T(testbase.ANTLRTest):
             "a b 3"
             )
 
-        self.failUnlessEqual("(a (b 3))", found)
+        self.assertEqual("(a (b 3))", found)
 
 
     def testDelete(self):
@@ -757,7 +757,7 @@ class T(testbase.ANTLRTest):
             "abc"
             )
 
-        self.failUnlessEqual("", found)
+        self.assertEqual("", found)
 
     def testSetMatchNoRewrite(self):
         grammar = textwrap.dedent(
@@ -792,7 +792,7 @@ class T(testbase.ANTLRTest):
             "abc 34"
             )
 
-        self.failUnlessEqual("abc 34", found)
+        self.assertEqual("abc 34", found)
 
 
     def testSetOptionalMatchNoRewrite(self):
@@ -826,7 +826,7 @@ class T(testbase.ANTLRTest):
             treeGrammar, 'a',
             "abc 34")
 
-        self.failUnlessEqual("abc 34", found)
+        self.assertEqual("abc 34", found)
 
 
     def testSetMatchNoRewriteLevel2(self):
@@ -861,7 +861,7 @@ class T(testbase.ANTLRTest):
             "abc 34"
             )
 
-        self.failUnlessEqual("(abc 34)", found)
+        self.assertEqual("(abc 34)", found)
 
 
     def testSetMatchNoRewriteLevel2Root(self):
@@ -896,7 +896,7 @@ class T(testbase.ANTLRTest):
             "abc 34"
             )
 
-        self.failUnlessEqual("(abc 34)", found)
+        self.assertEqual("(abc 34)", found)
 
 
     ## REWRITE MODE
@@ -936,7 +936,7 @@ class T(testbase.ANTLRTest):
             "abc 34"
             )
 
-        self.failUnlessEqual("(ick 34)", found)
+        self.assertEqual("(ick 34)", found)
 
 
         found = self.execTreeParser(
@@ -945,7 +945,7 @@ class T(testbase.ANTLRTest):
             "34"
             )
 
-        self.failUnlessEqual("34", found)
+        self.assertEqual("34", found)
 
 
     def testRewriteModeFlatTree(self):
@@ -1180,7 +1180,7 @@ class T(testbase.ANTLRTest):
             grammar, 'a',
             treeGrammar, 's',
             "abc 34")
-        self.failUnlessEqual("abc 34", found)
+        self.assertEqual("abc 34", found)
 
 
     def testRewriteOfRuleRefRoot(self):
@@ -1209,7 +1209,7 @@ class T(testbase.ANTLRTest):
         # emits whole tree when you ref the root since I can't know whether
         # you want the children or not.  You might be returning a whole new
         # tree.  Hmm...still seems weird.  oh well.
-        self.failUnlessEqual("(12 (abc 34))", found)
+        self.assertEqual("(12 (abc 34))", found)
 
 
     def testRewriteOfRuleRefRootLabeled(self):
@@ -1238,7 +1238,7 @@ class T(testbase.ANTLRTest):
         # emits whole tree when you ref the root since I can't know whether
         # you want the children or not.  You might be returning a whole new
         # tree.  Hmm...still seems weird.  oh well.
-        self.failUnlessEqual("(12 (abc 34))", found)
+        self.assertEqual("(12 (abc 34))", found)
 
 
     def testRewriteOfRuleRefRootListLabeled(self):
@@ -1267,7 +1267,7 @@ class T(testbase.ANTLRTest):
         # emits whole tree when you ref the root since I can't know whether
         # you want the children or not.  You might be returning a whole new
         # tree.  Hmm...still seems weird.  oh well.
-        self.failUnlessEqual("(12 (abc 34))", found)
+        self.assertEqual("(12 (abc 34))", found)
 
 
     def testRewriteOfRuleRefChild(self):
@@ -1293,7 +1293,7 @@ class T(testbase.ANTLRTest):
             grammar, 'a',
             treeGrammar, 's',
             "abc 34")
-        self.failUnlessEqual("(34 34)", found)
+        self.assertEqual("(34 34)", found)
 
 
     def testRewriteOfRuleRefLabel(self):
@@ -1319,7 +1319,7 @@ class T(testbase.ANTLRTest):
             grammar, 'a',
             treeGrammar, 's',
             "abc 34")
-        self.failUnlessEqual("(34 34)", found)
+        self.assertEqual("(34 34)", found)
 
 
     def testRewriteOfRuleRefListLabel(self):
@@ -1345,7 +1345,7 @@ class T(testbase.ANTLRTest):
             grammar, 'a',
             treeGrammar, 's',
             "abc 34")
-        self.failUnlessEqual("(34 34)", found)
+        self.assertEqual("(34 34)", found)
 
 
 
@@ -1385,7 +1385,7 @@ class T(testbase.ANTLRTest):
             "abc 34"
             )
 
-        self.failUnlessEqual("(root (ick 34))", found)
+        self.assertEqual("(root (ick 34))", found)
 
 
     def testWildcardSingleNode(self):
@@ -1421,7 +1421,7 @@ class T(testbase.ANTLRTest):
             "abc 34"
             )
 
-        self.failUnlessEqual("34", found)
+        self.assertEqual("34", found)
 
     def testWildcardUnlabeledSingleNode(self):
         grammar = textwrap.dedent(

--- a/runtime/Python/tests/t052import.py
+++ b/runtime/Python/tests/t052import.py
@@ -160,7 +160,7 @@ class T(testbase.ANTLRTest):
             input="b"
             )
 
-        self.failUnlessEqual("S.a", found)
+        self.assertEqual("S.a", found)
 
 
         # @Test public void testDelegatorInvokesDelegateRuleWithReturnStruct() throws Exception {
@@ -216,7 +216,7 @@ class T(testbase.ANTLRTest):
             input="b"
             )
 
-        self.failUnlessEqual("S.a1000", found)
+        self.assertEqual("S.a1000", found)
 
 
     def testDelegatorAccessesDelegateMembers(self):
@@ -253,7 +253,7 @@ class T(testbase.ANTLRTest):
             input="b"
             )
 
-        self.failUnlessEqual("foo", found)
+        self.assertEqual("foo", found)
 
 
     def testDelegatorInvokesFirstVersionOfDelegateRule(self):
@@ -302,7 +302,7 @@ class T(testbase.ANTLRTest):
             input="b"
             )
 
-        self.failUnlessEqual("S.a", found)
+        self.assertEqual("S.a", found)
 
 
     def testDelegatesSeeSameTokenType(self):
@@ -354,7 +354,7 @@ class T(testbase.ANTLRTest):
             input="aa"
             )
 
-        self.failUnlessEqual("S.x T.y", found)
+        self.assertEqual("S.x T.y", found)
 
 
         # @Test public void testDelegatesSeeSameTokenType2() throws Exception {
@@ -702,7 +702,7 @@ class T(testbase.ANTLRTest):
             input="c"
             )
 
-        self.failUnlessEqual("S.a", found)
+        self.assertEqual("S.a", found)
 
 
     #     @Test public void testDelegatorRuleOverridesLookaheadInDelegate() throws Exception {
@@ -789,7 +789,7 @@ class T(testbase.ANTLRTest):
             input="abc"
             )
 
-        self.failUnlessEqual("S.A abc", found)
+        self.assertEqual("S.A abc", found)
 
 
     def testLexerDelegatorRuleOverridesDelegate(self):
@@ -823,7 +823,7 @@ class T(testbase.ANTLRTest):
             input="a"
             )
 
-        self.failUnlessEqual("M.A a", found)
+        self.assertEqual("M.A a", found)
 
         # @Test public void testLexerDelegatorRuleOverridesDelegateLeavingNoRules() throws Exception {
         #         // M.Tokens has nothing to predict tokens from S.  Should

--- a/runtime/Python/tests/t053hetero.py
+++ b/runtime/Python/tests/t053hetero.py
@@ -122,7 +122,7 @@ class T(testbase.ANTLRTest):
             input="a"
             )
 
-        self.failUnlessEqual("a<V>", found)
+        self.assertEqual("a<V>", found)
 
 
     def testTokenCommonTree(self):
@@ -142,7 +142,7 @@ class T(testbase.ANTLRTest):
             grammar, 'a',
             input="a")
 
-        self.failUnlessEqual("a", found)
+        self.assertEqual("a", found)
 
 
     def testTokenWithQualifiedType(self):
@@ -169,7 +169,7 @@ class T(testbase.ANTLRTest):
             input="a"
             )
 
-        self.failUnlessEqual("a<V>", found)
+        self.assertEqual("a<V>", found)
 
 
     def testNamedType(self):
@@ -220,7 +220,7 @@ class T(testbase.ANTLRTest):
             input="a"
             )
 
-        self.failUnlessEqual("a<V>", found)
+        self.assertEqual("a<V>", found)
 
 
     def testTokenWithListLabel(self):
@@ -248,7 +248,7 @@ class T(testbase.ANTLRTest):
             input="a"
             )
 
-        self.failUnlessEqual("a<V>", found)
+        self.assertEqual("a<V>", found)
 
 
     def testTokenRoot(self):
@@ -276,7 +276,7 @@ class T(testbase.ANTLRTest):
             input="a"
             )
 
-        self.failUnlessEqual("a<V>", found)
+        self.assertEqual("a<V>", found)
 
 
     def testTokenRootWithListLabel(self):
@@ -304,7 +304,7 @@ class T(testbase.ANTLRTest):
             input="a"
             )
 
-        self.failUnlessEqual("a<V>", found)
+        self.assertEqual("a<V>", found)
 
 
     def testString(self):
@@ -332,7 +332,7 @@ class T(testbase.ANTLRTest):
             input="begin"
             )
 
-        self.failUnlessEqual("begin<V>", found)
+        self.assertEqual("begin<V>", found)
 
 
     def testStringRoot(self):
@@ -360,7 +360,7 @@ class T(testbase.ANTLRTest):
             input="begin"
             )
 
-        self.failUnlessEqual("begin<V>", found)
+        self.assertEqual("begin<V>", found)
 
 
     # PARSERS -- REWRITE AST
@@ -390,7 +390,7 @@ class T(testbase.ANTLRTest):
             input="a"
             )
 
-        self.failUnlessEqual("a<V>", found)
+        self.assertEqual("a<V>", found)
 
 
     def testRewriteTokenWithArgs(self):
@@ -444,7 +444,7 @@ class T(testbase.ANTLRTest):
             input="a"
             )
 
-        self.failUnlessEqual("<V>;421930 a<V>;9900", found)
+        self.assertEqual("<V>;421930 a<V>;9900", found)
 
 
     def testRewriteTokenRoot(self):
@@ -473,7 +473,7 @@ class T(testbase.ANTLRTest):
             input="a 2"
             )
 
-        self.failUnlessEqual("(a<V> 2)", found)
+        self.assertEqual("(a<V> 2)", found)
 
 
     def testRewriteString(self):
@@ -501,7 +501,7 @@ class T(testbase.ANTLRTest):
             input="begin"
             )
 
-        self.failUnlessEqual("begin<V>", found)
+        self.assertEqual("begin<V>", found)
 
 
     def testRewriteStringRoot(self):
@@ -530,7 +530,7 @@ class T(testbase.ANTLRTest):
             input="begin 2"
             )
 
-        self.failUnlessEqual("(begin<V> 2)", found)
+        self.assertEqual("(begin<V> 2)", found)
 
     def testRewriteRuleResults(self):
         grammar = textwrap.dedent(
@@ -567,7 +567,7 @@ class T(testbase.ANTLRTest):
             grammar, 'a',
             input="a,b,c")
 
-        self.failUnlessEqual("(LIST<W> a<V> b<V> c<V>)", found)
+        self.assertEqual("(LIST<W> a<V> b<V> c<V>)", found)
 
     def testCopySemanticsWithHetero(self):
         grammar = textwrap.dedent(
@@ -597,7 +597,7 @@ class T(testbase.ANTLRTest):
         found = self.execParser(
             grammar, 'a',
             input="int a, b, c;")
-        self.failUnlessEqual("(int<V> a) (int<V> b) (int<V> c)", found)
+        self.assertEqual("(int<V> a) (int<V> b) (int<V> c)", found)
 
     # TREE PARSERS -- REWRITE AST
 
@@ -646,7 +646,7 @@ class T(testbase.ANTLRTest):
             input="abc 34"
             )
 
-        self.failUnlessEqual("34<V> abc<W>", found)
+        self.assertEqual("34<V> abc<W>", found)
 
 
     def testTreeParserRewriteTree(self):
@@ -694,7 +694,7 @@ class T(testbase.ANTLRTest):
             input="abc 34"
             )
 
-        self.failUnlessEqual("(34<V> abc<W>)", found)
+        self.assertEqual("(34<V> abc<W>)", found)
 
 
     def testTreeParserRewriteImaginary(self):
@@ -742,7 +742,7 @@ class T(testbase.ANTLRTest):
             input="abc"
             )
 
-        self.failUnlessEqual("ROOT<V> abc", found)
+        self.assertEqual("ROOT<V> abc", found)
 
 
     def testTreeParserRewriteImaginaryWithArgs(self):
@@ -790,7 +790,7 @@ class T(testbase.ANTLRTest):
             input="abc"
             )
 
-        self.failUnlessEqual("ROOT<V>;42 abc", found)
+        self.assertEqual("ROOT<V>;42 abc", found)
 
 
     def testTreeParserRewriteImaginaryRoot(self):
@@ -837,7 +837,7 @@ class T(testbase.ANTLRTest):
             input="abc"
             )
 
-        self.failUnlessEqual("(ROOT<V> abc)", found)
+        self.assertEqual("(ROOT<V> abc)", found)
 
 
     def testTreeParserRewriteImaginaryFromReal(self):
@@ -888,7 +888,7 @@ class T(testbase.ANTLRTest):
             input="abc"
             )
 
-        self.failUnlessEqual("ROOT<V>@1", found)
+        self.assertEqual("ROOT<V>@1", found)
 
 
     def testTreeParserAutoHeteroAST(self):
@@ -932,7 +932,7 @@ class T(testbase.ANTLRTest):
             input="abc;"
             )
 
-        self.failUnlessEqual("abc<V> ;<V>", found)
+        self.assertEqual("abc<V> ;<V>", found)
 
 
 if __name__ == '__main__':

--- a/runtime/Python/tests/t054main.py
+++ b/runtime/Python/tests/t054main.py
@@ -70,7 +70,7 @@ class T(testbase.ANTLRTest):
             stdout=stdout
             )
 
-        self.failUnlessEqual(len(stdout.getvalue().splitlines()), 3)
+        self.assertEqual(len(stdout.getvalue().splitlines()), 3)
 
 
     def testLexerFromStdIO(self):
@@ -96,7 +96,7 @@ class T(testbase.ANTLRTest):
             stdout=stdout
             )
 
-        self.failUnlessEqual(len(stdout.getvalue().splitlines()), 3)
+        self.assertEqual(len(stdout.getvalue().splitlines()), 3)
 
 
     def testLexerEncoding(self):
@@ -122,7 +122,7 @@ class T(testbase.ANTLRTest):
             stdout=stdout
             )
 
-        self.failUnlessEqual(len(stdout.getvalue().splitlines()), 3)
+        self.assertEqual(len(stdout.getvalue().splitlines()), 3)
 
 
     def testCombined(self):
@@ -151,7 +151,7 @@ class T(testbase.ANTLRTest):
             )
 
         stdout = stdout.getvalue()
-        self.failUnlessEqual(len(stdout.splitlines()), 1, stdout)
+        self.assertEqual(len(stdout.splitlines()), 1, stdout)
 
 
     def testCombinedOutputAST(self):
@@ -182,7 +182,7 @@ class T(testbase.ANTLRTest):
             )
 
         stdout = stdout.getvalue().strip()
-        self.failUnlessEqual(stdout, "(+ foo bar)")
+        self.assertEqual(stdout, "(+ foo bar)")
 
 
     def testTreeParser(self):
@@ -223,7 +223,7 @@ class T(testbase.ANTLRTest):
             )
 
         stdout = stdout.getvalue().strip()
-        self.failUnlessEqual(stdout, "u'a + b'")
+        self.assertEqual(stdout, "u'a + b'")
 
 
     def testTreeParserRewrite(self):
@@ -266,7 +266,7 @@ class T(testbase.ANTLRTest):
             )
 
         stdout = stdout.getvalue().strip()
-        self.failUnlessEqual(stdout, "(+ (ARG a) (ARG b))")
+        self.assertEqual(stdout, "(+ (ARG a) (ARG b))")
 
 
 
@@ -311,7 +311,7 @@ class T(testbase.ANTLRTest):
             )
 
         stdout = stdout.getvalue().strip()
-        self.failUnlessEqual(stdout, "u'b'")
+        self.assertEqual(stdout, "u'b'")
 
 
 if __name__ == '__main__':

--- a/runtime/Python/tests/t055templates.py
+++ b/runtime/Python/tests/t055templates.py
@@ -47,7 +47,7 @@ class T(testbase.ANTLRTest):
             "abc 34"
             )
 
-        self.failUnlessEqual("id=abc, int=34", found)
+        self.assertEqual("id=abc, int=34", found)
 
 
     def testExternalTemplate(self):
@@ -88,7 +88,7 @@ class T(testbase.ANTLRTest):
             group
             )
 
-        self.failUnlessEqual("[a+b]", found)
+        self.assertEqual("[a+b]", found)
 
 
     def testEmptyTemplate(self):
@@ -113,7 +113,7 @@ class T(testbase.ANTLRTest):
             "abc 34"
             )
 
-        self.failUnless(found is None)
+        self.assertTrue(found is None)
 
 
     def testList(self):
@@ -142,7 +142,7 @@ class T(testbase.ANTLRTest):
             "abc def ghi"
             )
 
-        self.failUnlessEqual("abc,def,ghi", found)
+        self.assertEqual("abc,def,ghi", found)
 
 
     def testAction(self):
@@ -166,7 +166,7 @@ class T(testbase.ANTLRTest):
             "abc"
             )
 
-        self.failUnlessEqual("hello", found)
+        self.assertEqual("hello", found)
 
 
     def testTemplateExpressionInAction(self):
@@ -190,7 +190,7 @@ class T(testbase.ANTLRTest):
             "abc"
             )
 
-        self.failUnlessEqual("hello", found)
+        self.assertEqual("hello", found)
 
 
     def testTemplateExpressionInAction2(self):
@@ -218,7 +218,7 @@ class T(testbase.ANTLRTest):
             "abc"
             )
 
-        self.failUnlessEqual("hello world", found)
+        self.assertEqual("hello world", found)
 
 
     def testIndirectTemplateConstructor(self):
@@ -259,7 +259,7 @@ class T(testbase.ANTLRTest):
             group
             )
 
-        self.failUnlessEqual("[1+2+3]", found)
+        self.assertEqual("[1+2+3]", found)
 
 
     def testPredicates(self):
@@ -289,7 +289,7 @@ class T(testbase.ANTLRTest):
             "b 34"
             )
 
-        self.failUnlessEqual("B: 34", found)
+        self.assertEqual("B: 34", found)
 
 
     def testBacktrackingMode(self):
@@ -316,7 +316,7 @@ class T(testbase.ANTLRTest):
             "abc 34"
             )
 
-        self.failUnlessEqual("id=abc, int=34", found)
+        self.assertEqual("id=abc, int=34", found)
 
 
     def testRewrite(self):
@@ -388,7 +388,7 @@ class T(testbase.ANTLRTest):
             '''
             )
 
-        self.failUnlessEqual(expected, found)
+        self.assertEqual(expected, found)
 
 
     def testTreeRewrite(self):
@@ -501,7 +501,7 @@ class T(testbase.ANTLRTest):
             '''
             )
 
-        self.failUnlessEqual(expected, found)
+        self.assertEqual(expected, found)
 
 
 if __name__ == '__main__':

--- a/runtime/Python/tests/t056lexer.py
+++ b/runtime/Python/tests/t056lexer.py
@@ -42,7 +42,7 @@ class T(testbase.ANTLRTest):
             "- 34"
             )
 
-        self.failUnlessEqual("- 34, channel=0", found)
+        self.assertEqual("- 34, channel=0", found)
 
         
 if __name__ == '__main__':

--- a/runtime/Python/tests/t057autoAST.py
+++ b/runtime/Python/tests/t057autoAST.py
@@ -491,8 +491,6 @@ class TestAutoAST(testbase.ANTLRTest):
         self.assertEquals("(+ abc)", found)
 
 
-    @testbase.broken(
-        "FAILS until antlr.g rebuilt in v3", testbase.GrammarCompileError)
     def testSetRootWithLabel(self):
         grammar = textwrap.dedent(
             r'''
@@ -846,7 +844,7 @@ class TestAutoAST(testbase.ANTLRTest):
 
         found, errors = self.execParser(grammar, "decl", "int 34 x=1;",
                                         expectErrors=True)
-        self.assertEquals(["line 1:4 extraneous input u'34' expecting ID"],
+        self.assertListEqual(["line 1:4 extraneous input u'34' expecting ID"],
                           errors)
         self.assertEquals("(int x 1)", found) # tree gets correct x and 1 tokens
 
@@ -866,7 +864,7 @@ class TestAutoAST(testbase.ANTLRTest):
 
         found, errors = self.execParser(grammar, "decl", "int =1;",
                                         expectErrors=True)
-        self.assertEquals(["line 1:4 missing ID at u'='"], errors)
+        self.assertListEqual(["line 1:4 missing ID at u'='"], errors)
         self.assertEquals("(int <missing ID> 1)", found) # tree gets invented ID token
 
 
@@ -885,7 +883,7 @@ class TestAutoAST(testbase.ANTLRTest):
 
         found, errors = self.execParser(grammar, "decl", "x=1;",
                                         expectErrors=True)
-        self.assertEquals(["line 1:0 mismatched input u'x' expecting set None"], errors)
+        self.assertListEqual(["line 1:0 mismatched input u'x' expecting set None"], errors)
         self.assertEquals("(<error: x> x 1)", found) # tree gets invented ID token
 
 
@@ -901,7 +899,7 @@ class TestAutoAST(testbase.ANTLRTest):
             ''')
 
         found, errors = self.execParser(grammar, "a", "abc", expectErrors=True)
-        self.assertEquals(["line 1:3 missing INT at '<EOF>'"], errors)
+        self.assertListEqual(["line 1:3 missing INT at '<EOF>'"], errors)
         self.assertEquals("abc <missing INT>", found)
 
 
@@ -918,7 +916,7 @@ class TestAutoAST(testbase.ANTLRTest):
             ''')
 
         found, errors = self.execParser(grammar, "a", "abc", expectErrors=True)
-        self.assertEquals(["line 1:3 mismatched input '<EOF>' expecting INT"], errors)
+        self.assertListEqual(["line 1:3 mismatched input '<EOF>' expecting INT"], errors)
         self.assertEquals("<mismatched token: <EOF>, resync=abc>", found)
 
 
@@ -937,7 +935,7 @@ class TestAutoAST(testbase.ANTLRTest):
 
         found, errors = self.execParser(grammar, "a", "abc ick 34",
                                         expectErrors=True)
-        self.assertEquals(["line 1:4 extraneous input u'ick' expecting INT"],
+        self.assertListEqual(["line 1:4 extraneous input u'ick' expecting INT"],
                           errors)
         self.assertEquals("abc 34", found)
 
@@ -954,7 +952,7 @@ class TestAutoAST(testbase.ANTLRTest):
             ''')
 
         found, errors = self.execParser(grammar, "a", "34", expectErrors=True)
-        self.assertEquals(["line 1:0 missing ID at u'34'"], errors)
+        self.assertListEqual(["line 1:0 missing ID at u'34'"], errors)
         self.assertEquals("<missing ID> 34", found)
 
 
@@ -976,7 +974,7 @@ class TestAutoAST(testbase.ANTLRTest):
         # finds an error at the first token, 34, and re-syncs.
         # re-synchronizing does not consume a token because 34 follows
         # ref to rule b (start of c). It then matches 34 in c.
-        self.assertEquals(["line 1:0 missing ID at u'34'"], errors)
+        self.assertListEqual(["line 1:0 missing ID at u'34'"], errors)
         self.assertEquals("<missing ID> 34", found)
 
 
@@ -995,7 +993,7 @@ class TestAutoAST(testbase.ANTLRTest):
             ''')
 
         found, errors = self.execParser(grammar, "a", "*", expectErrors=True)
-        self.assertEquals(["line 1:0 no viable alternative at input u'*'"],
+        self.assertListEqual(["line 1:0 no viable alternative at input u'*'"],
                           errors)
         self.assertEquals("<unexpected: [@0,0:0=u'*',<6>,1:0], resync=*>",
                           found)

--- a/runtime/Python/tests/t058rewriteAST.py
+++ b/runtime/Python/tests/t058rewriteAST.py
@@ -1202,8 +1202,6 @@ class TestRewriteAST(testbase.ANTLRTest):
         self.assertEquals("2", found)
 
 
-    @testbase.broken("http://www.antlr.org:8888/browse/ANTLR-162",
-                     antlr3.tree.RewriteEmptyStreamException)
     def testSetWithLabel(self):
         grammar = textwrap.dedent(
             r'''
@@ -1367,7 +1365,7 @@ class TestRewriteAST(testbase.ANTLRTest):
 
         found, errors = self.execParser(grammar, "decl", "int 34 x=1;",
                                         expectErrors=True)
-        self.assertEquals(["line 1:4 extraneous input u'34' expecting ID"],
+        self.assertListEqual(["line 1:4 extraneous input u'34' expecting ID"],
                           errors)
         self.assertEquals("(EXPR int x 1)", found) # tree gets correct x and 1 tokens
 
@@ -1388,7 +1386,7 @@ class TestRewriteAST(testbase.ANTLRTest):
 
         found, errors = self.execParser(grammar, "decl", "int =1;",
                                         expectErrors=True)
-        self.assertEquals(["line 1:4 missing ID at u'='"], errors)
+        self.assertListEqual(["line 1:4 missing ID at u'='"], errors)
         self.assertEquals("(EXPR int <missing ID> 1)", found) # tree gets invented ID token
 
 
@@ -1407,7 +1405,7 @@ class TestRewriteAST(testbase.ANTLRTest):
 
         found, errors = self.execParser(grammar, "decl", "x=1;",
                                         expectErrors=True)
-        self.assertEquals(["line 1:0 mismatched input u'x' expecting set None"],
+        self.assertListEqual(["line 1:0 mismatched input u'x' expecting set None"],
                           errors);
         self.assertEquals("(EXPR <error: x> x 1)", found) # tree gets invented ID token
 
@@ -1425,7 +1423,7 @@ class TestRewriteAST(testbase.ANTLRTest):
 
         found, errors = self.execParser(grammar, "a", "abc",
                                         expectErrors=True)
-        self.assertEquals(["line 1:3 missing INT at '<EOF>'"], errors)
+        self.assertListEqual(["line 1:3 missing INT at '<EOF>'"], errors)
         # doesn't do in-line recovery for sets (yet?)
         self.assertEquals("abc <missing INT>", found)
 
@@ -1445,7 +1443,7 @@ class TestRewriteAST(testbase.ANTLRTest):
 
         found, errors = self.execParser(grammar, "a", "abc ick 34",
                                         expectErrors=True)
-        self.assertEquals(["line 1:4 extraneous input u'ick' expecting INT"],
+        self.assertListEqual(["line 1:4 extraneous input u'ick' expecting INT"],
                           errors)
         self.assertEquals("abc 34", found)
 
@@ -1463,7 +1461,7 @@ class TestRewriteAST(testbase.ANTLRTest):
             ''')
 
         found, errors = self.execParser(grammar, "a", "34", expectErrors=True)
-        self.assertEquals(["line 1:0 missing ID at u'34'"], errors)
+        self.assertListEqual(["line 1:0 missing ID at u'34'"], errors)
         self.assertEquals("<missing ID> 34", found)
 
 
@@ -1485,7 +1483,7 @@ class TestRewriteAST(testbase.ANTLRTest):
         # finds an error at the first token, 34, and re-syncs.
         # re-synchronizing does not consume a token because 34 follows
         # ref to rule b (start of c). It then matches 34 in c.
-        self.assertEquals(["line 1:0 missing ID at u'34'"], errors)
+        self.assertListEqual(["line 1:0 missing ID at u'34'"], errors)
         self.assertEquals("<missing ID> 34", found)
 
 
@@ -1507,7 +1505,7 @@ class TestRewriteAST(testbase.ANTLRTest):
         # finds an error at the first token, 34, and re-syncs.
         # re-synchronizing does not consume a token because 34 follows
         # ref to rule b (start of c). It then matches 34 in c.
-        self.assertEquals(["line 1:0 no viable alternative at input u'*'"],
+        self.assertListEqual(["line 1:0 no viable alternative at input u'*'"],
                           errors);
         self.assertEquals("<unexpected: [@0,0:0=u'*',<6>,1:0], resync=*>",
                           found)

--- a/runtime/Python/unittests/testdfa.py
+++ b/runtime/Python/unittests/testdfa.py
@@ -42,7 +42,7 @@ class TestDFA(unittest.TestCase):
     def testUnpack(self):
         """DFA.unpack()"""
 
-        self.failUnlessEqual(
+        self.assertListEqual(
             antlr3.DFA.unpack(
             u"\1\3\1\4\2\uffff\1\5\22\uffff\1\2\31\uffff\1\6\6\uffff"
             u"\32\6\4\uffff\1\6\1\uffff\32\6"

--- a/runtime/Python/unittests/testrecognizers.py
+++ b/runtime/Python/unittests/testrecognizers.py
@@ -11,7 +11,7 @@ class TestBaseRecognizer(unittest.TestCase):
         """BaseRecognizer._getRuleInvocationStack()"""
 
         rules = antlr3.BaseRecognizer._getRuleInvocationStack(__name__)
-        self.failUnlessEqual(
+        self.assertListEqual(
             rules,
             ['testGetRuleInvocationStack']
             )
@@ -47,7 +47,7 @@ class TestTokenSource(unittest.TestCase):
         for token in src:
             tokens.append(token.type)
 
-        self.failUnlessEqual(tokens, [1, 2, 3, 4])
+        self.assertListEqual(tokens, [1, 2, 3, 4])
 
 
 

--- a/runtime/Python/unittests/teststreams.py
+++ b/runtime/Python/unittests/teststreams.py
@@ -14,7 +14,7 @@ class TestStringStream(unittest.TestCase):
 
         stream = antlr3.StringStream('foo')
 
-        self.failUnlessEqual(stream.size(), 3)
+        self.assertEqual(stream.size(), 3)
 
 
     def testIndex(self):
@@ -22,7 +22,7 @@ class TestStringStream(unittest.TestCase):
 
         stream = antlr3.StringStream('foo')
 
-        self.failUnlessEqual(stream.index(), 0)
+        self.assertEqual(stream.index(), 0)
 
 
     def testConsume(self):
@@ -31,49 +31,49 @@ class TestStringStream(unittest.TestCase):
         stream = antlr3.StringStream('foo\nbar')
 
         stream.consume() # f
-        self.failUnlessEqual(stream.index(), 1)
-        self.failUnlessEqual(stream.charPositionInLine, 1)
-        self.failUnlessEqual(stream.line, 1)
+        self.assertEqual(stream.index(), 1)
+        self.assertEqual(stream.charPositionInLine, 1)
+        self.assertEqual(stream.line, 1)
 
         stream.consume() # o
-        self.failUnlessEqual(stream.index(), 2)
-        self.failUnlessEqual(stream.charPositionInLine, 2)
-        self.failUnlessEqual(stream.line, 1)
+        self.assertEqual(stream.index(), 2)
+        self.assertEqual(stream.charPositionInLine, 2)
+        self.assertEqual(stream.line, 1)
 
         stream.consume() # o
-        self.failUnlessEqual(stream.index(), 3)
-        self.failUnlessEqual(stream.charPositionInLine, 3)
-        self.failUnlessEqual(stream.line, 1)
+        self.assertEqual(stream.index(), 3)
+        self.assertEqual(stream.charPositionInLine, 3)
+        self.assertEqual(stream.line, 1)
 
         stream.consume() # \n
-        self.failUnlessEqual(stream.index(), 4)
-        self.failUnlessEqual(stream.charPositionInLine, 0)
-        self.failUnlessEqual(stream.line, 2)
+        self.assertEqual(stream.index(), 4)
+        self.assertEqual(stream.charPositionInLine, 0)
+        self.assertEqual(stream.line, 2)
 
         stream.consume() # b
-        self.failUnlessEqual(stream.index(), 5)
-        self.failUnlessEqual(stream.charPositionInLine, 1)
-        self.failUnlessEqual(stream.line, 2)
+        self.assertEqual(stream.index(), 5)
+        self.assertEqual(stream.charPositionInLine, 1)
+        self.assertEqual(stream.line, 2)
 
         stream.consume() # a
-        self.failUnlessEqual(stream.index(), 6)
-        self.failUnlessEqual(stream.charPositionInLine, 2)
-        self.failUnlessEqual(stream.line, 2)
+        self.assertEqual(stream.index(), 6)
+        self.assertEqual(stream.charPositionInLine, 2)
+        self.assertEqual(stream.line, 2)
 
         stream.consume() # r
-        self.failUnlessEqual(stream.index(), 7)
-        self.failUnlessEqual(stream.charPositionInLine, 3)
-        self.failUnlessEqual(stream.line, 2)
+        self.assertEqual(stream.index(), 7)
+        self.assertEqual(stream.charPositionInLine, 3)
+        self.assertEqual(stream.line, 2)
 
         stream.consume() # EOF
-        self.failUnlessEqual(stream.index(), 7)
-        self.failUnlessEqual(stream.charPositionInLine, 3)
-        self.failUnlessEqual(stream.line, 2)
+        self.assertEqual(stream.index(), 7)
+        self.assertEqual(stream.charPositionInLine, 3)
+        self.assertEqual(stream.line, 2)
 
         stream.consume() # EOF
-        self.failUnlessEqual(stream.index(), 7)
-        self.failUnlessEqual(stream.charPositionInLine, 3)
-        self.failUnlessEqual(stream.line, 2)
+        self.assertEqual(stream.index(), 7)
+        self.assertEqual(stream.charPositionInLine, 3)
+        self.assertEqual(stream.line, 2)
 
 
     def testReset(self):
@@ -85,10 +85,10 @@ class TestStringStream(unittest.TestCase):
         stream.consume()
 
         stream.reset()
-        self.failUnlessEqual(stream.index(), 0)
-        self.failUnlessEqual(stream.line, 1)
-        self.failUnlessEqual(stream.charPositionInLine, 0)
-        self.failUnlessEqual(stream.LT(1), 'f')
+        self.assertEqual(stream.index(), 0)
+        self.assertEqual(stream.line, 1)
+        self.assertEqual(stream.charPositionInLine, 0)
+        self.assertEqual(stream.LT(1), 'f')
 
 
     def testLA(self):
@@ -96,16 +96,16 @@ class TestStringStream(unittest.TestCase):
 
         stream = antlr3.StringStream('foo')
 
-        self.failUnlessEqual(stream.LT(1), 'f')
-        self.failUnlessEqual(stream.LT(2), 'o')
-        self.failUnlessEqual(stream.LT(3), 'o')
+        self.assertEqual(stream.LT(1), 'f')
+        self.assertEqual(stream.LT(2), 'o')
+        self.assertEqual(stream.LT(3), 'o')
 
         stream.consume()
         stream.consume()
 
-        self.failUnlessEqual(stream.LT(1), 'o')
-        self.failUnlessEqual(stream.LT(2), antlr3.EOF)
-        self.failUnlessEqual(stream.LT(3), antlr3.EOF)
+        self.assertEqual(stream.LT(1), 'o')
+        self.assertEqual(stream.LT(2), antlr3.EOF)
+        self.assertEqual(stream.LT(3), antlr3.EOF)
 
 
     def testSubstring(self):
@@ -113,10 +113,10 @@ class TestStringStream(unittest.TestCase):
 
         stream = antlr3.StringStream('foobar')
 
-        self.failUnlessEqual(stream.substring(0, 0), 'f')
-        self.failUnlessEqual(stream.substring(0, 1), 'fo')
-        self.failUnlessEqual(stream.substring(0, 5), 'foobar')
-        self.failUnlessEqual(stream.substring(3, 5), 'bar')
+        self.assertEqual(stream.substring(0, 0), 'f')
+        self.assertEqual(stream.substring(0, 1), 'fo')
+        self.assertEqual(stream.substring(0, 5), 'foobar')
+        self.assertEqual(stream.substring(3, 5), 'bar')
 
 
     def testSeekForward(self):
@@ -126,10 +126,10 @@ class TestStringStream(unittest.TestCase):
 
         stream.seek(4)
 
-        self.failUnlessEqual(stream.index(), 4)
-        self.failUnlessEqual(stream.line, 2)
-        self.failUnlessEqual(stream.charPositionInLine, 0)
-        self.failUnlessEqual(stream.LT(1), 'b')
+        self.assertEqual(stream.index(), 4)
+        self.assertEqual(stream.line, 2)
+        self.assertEqual(stream.charPositionInLine, 0)
+        self.assertEqual(stream.LT(1), 'b')
 
 
 ##     # not yet implemented
@@ -141,10 +141,10 @@ class TestStringStream(unittest.TestCase):
 ##         stream.seek(4)
 ##         stream.seek(1)
 
-##         self.failUnlessEqual(stream.index(), 1)
-##         self.failUnlessEqual(stream.line, 1)
-##         self.failUnlessEqual(stream.charPositionInLine, 1)
-##         self.failUnlessEqual(stream.LA(1), 'o')
+##         self.assertEqual(stream.index(), 1)
+##         self.assertEqual(stream.line, 1)
+##         self.assertEqual(stream.charPositionInLine, 1)
+##         self.assertEqual(stream.LA(1), 'o')
 
 
     def testMark(self):
@@ -155,13 +155,13 @@ class TestStringStream(unittest.TestCase):
         stream.seek(4)
 
         marker = stream.mark()
-        self.failUnlessEqual(marker, 1)
-        self.failUnlessEqual(stream.markDepth, 1)
+        self.assertEqual(marker, 1)
+        self.assertEqual(stream.markDepth, 1)
 
         stream.consume()
         marker = stream.mark()
-        self.failUnlessEqual(marker, 2)
-        self.failUnlessEqual(stream.markDepth, 2)
+        self.assertEqual(marker, 2)
+        self.assertEqual(stream.markDepth, 2)
 
 
     def testReleaseLast(self):
@@ -176,11 +176,11 @@ class TestStringStream(unittest.TestCase):
         marker2 = stream.mark()
 
         stream.release()
-        self.failUnlessEqual(stream.markDepth, 1)
+        self.assertEqual(stream.markDepth, 1)
 
         # release same marker again, nothing has changed
         stream.release()
-        self.failUnlessEqual(stream.markDepth, 1)
+        self.assertEqual(stream.markDepth, 1)
 
 
     def testReleaseNested(self):
@@ -198,7 +198,7 @@ class TestStringStream(unittest.TestCase):
         marker3 = stream.mark()
 
         stream.release(marker2)
-        self.failUnlessEqual(stream.markDepth, 1)
+        self.assertEqual(stream.markDepth, 1)
 
 
     def testRewindLast(self):
@@ -213,11 +213,11 @@ class TestStringStream(unittest.TestCase):
         stream.consume()
 
         stream.rewind()
-        self.failUnlessEqual(stream.markDepth, 0)
-        self.failUnlessEqual(stream.index(), 4)
-        self.failUnlessEqual(stream.line, 2)
-        self.failUnlessEqual(stream.charPositionInLine, 0)
-        self.failUnlessEqual(stream.LT(1), 'b')
+        self.assertEqual(stream.markDepth, 0)
+        self.assertEqual(stream.index(), 4)
+        self.assertEqual(stream.line, 2)
+        self.assertEqual(stream.charPositionInLine, 0)
+        self.assertEqual(stream.LT(1), 'b')
 
 
     def testRewindNested(self):
@@ -235,11 +235,11 @@ class TestStringStream(unittest.TestCase):
         marker3 = stream.mark()
 
         stream.rewind(marker2)
-        self.failUnlessEqual(stream.markDepth, 1)
-        self.failUnlessEqual(stream.index(), 5)
-        self.failUnlessEqual(stream.line, 2)
-        self.failUnlessEqual(stream.charPositionInLine, 1)
-        self.failUnlessEqual(stream.LT(1), 'a')
+        self.assertEqual(stream.markDepth, 1)
+        self.assertEqual(stream.index(), 5)
+        self.assertEqual(stream.line, 2)
+        self.assertEqual(stream.charPositionInLine, 1)
+        self.assertEqual(stream.LT(1), 'a')
 
 
 class TestFileStream(unittest.TestCase):
@@ -261,12 +261,12 @@ class TestFileStream(unittest.TestCase):
         marker3 = stream.mark()
 
         stream.rewind(marker2)
-        self.failUnlessEqual(stream.markDepth, 1)
-        self.failUnlessEqual(stream.index(), 5)
-        self.failUnlessEqual(stream.line, 2)
-        self.failUnlessEqual(stream.charPositionInLine, 1)
-        self.failUnlessEqual(stream.LT(1), 'a')
-        self.failUnlessEqual(stream.LA(1), ord('a'))
+        self.assertEqual(stream.markDepth, 1)
+        self.assertEqual(stream.index(), 5)
+        self.assertEqual(stream.line, 2)
+        self.assertEqual(stream.charPositionInLine, 1)
+        self.assertEqual(stream.LT(1), 'a')
+        self.assertEqual(stream.LA(1), ord('a'))
 
 
     def testEncoded(self):
@@ -284,12 +284,12 @@ class TestFileStream(unittest.TestCase):
         marker3 = stream.mark()
 
         stream.rewind(marker2)
-        self.failUnlessEqual(stream.markDepth, 1)
-        self.failUnlessEqual(stream.index(), 5)
-        self.failUnlessEqual(stream.line, 2)
-        self.failUnlessEqual(stream.charPositionInLine, 1)
-        self.failUnlessEqual(stream.LT(1), u'ä')
-        self.failUnlessEqual(stream.LA(1), ord(u'ä'))
+        self.assertEqual(stream.markDepth, 1)
+        self.assertEqual(stream.index(), 5)
+        self.assertEqual(stream.line, 2)
+        self.assertEqual(stream.charPositionInLine, 1)
+        self.assertEqual(stream.LT(1), u'ä')
+        self.assertEqual(stream.LA(1), ord(u'ä'))
 
 
 
@@ -311,12 +311,12 @@ class TestInputStream(unittest.TestCase):
         marker3 = stream.mark()
 
         stream.rewind(marker2)
-        self.failUnlessEqual(stream.markDepth, 1)
-        self.failUnlessEqual(stream.index(), 5)
-        self.failUnlessEqual(stream.line, 2)
-        self.failUnlessEqual(stream.charPositionInLine, 1)
-        self.failUnlessEqual(stream.LT(1), 'a')
-        self.failUnlessEqual(stream.LA(1), ord('a'))
+        self.assertEqual(stream.markDepth, 1)
+        self.assertEqual(stream.index(), 5)
+        self.assertEqual(stream.line, 2)
+        self.assertEqual(stream.charPositionInLine, 1)
+        self.assertEqual(stream.LT(1), 'a')
+        self.assertEqual(stream.LA(1), ord('a'))
 
 
     def testEncoded(self):
@@ -334,12 +334,12 @@ class TestInputStream(unittest.TestCase):
         marker3 = stream.mark()
 
         stream.rewind(marker2)
-        self.failUnlessEqual(stream.markDepth, 1)
-        self.failUnlessEqual(stream.index(), 5)
-        self.failUnlessEqual(stream.line, 2)
-        self.failUnlessEqual(stream.charPositionInLine, 1)
-        self.failUnlessEqual(stream.LT(1), u'ä')
-        self.failUnlessEqual(stream.LA(1), ord(u'ä'))
+        self.assertEqual(stream.markDepth, 1)
+        self.assertEqual(stream.index(), 5)
+        self.assertEqual(stream.line, 2)
+        self.assertEqual(stream.charPositionInLine, 1)
+        self.assertEqual(stream.LT(1), u'ä')
+        self.assertEqual(stream.LA(1), ord(u'ä'))
 
 
 class TestCommonTokenStream(unittest.TestCase):
@@ -373,7 +373,7 @@ class TestCommonTokenStream(unittest.TestCase):
         """CommonTokenStream.__init__()"""
 
         stream = antlr3.CommonTokenStream(self.source)
-        self.failUnlessEqual(stream.index(), -1)
+        self.assertEqual(stream.index(), -1)
 
 
     def testSetTokenSource(self):
@@ -381,8 +381,8 @@ class TestCommonTokenStream(unittest.TestCase):
 
         stream = antlr3.CommonTokenStream(None)
         stream.setTokenSource(self.source)
-        self.failUnlessEqual(stream.index(), -1)
-        self.failUnlessEqual(stream.channel, antlr3.DEFAULT_CHANNEL)
+        self.assertEqual(stream.index(), -1)
+        self.assertEqual(stream.channel, antlr3.DEFAULT_CHANNEL)
 
 
     def testLTEmptySource(self):
@@ -391,7 +391,7 @@ class TestCommonTokenStream(unittest.TestCase):
         stream = antlr3.CommonTokenStream(self.source)
 
         lt1 = stream.LT(1)
-        self.failUnlessEqual(lt1.type, antlr3.EOF)
+        self.assertEqual(lt1.type, antlr3.EOF)
 
 
     def testLT1(self):
@@ -404,7 +404,7 @@ class TestCommonTokenStream(unittest.TestCase):
         stream = antlr3.CommonTokenStream(self.source)
 
         lt1 = stream.LT(1)
-        self.failUnlessEqual(lt1.type, 12)
+        self.assertEqual(lt1.type, 12)
 
 
     def testLT1WithHidden(self):
@@ -421,7 +421,7 @@ class TestCommonTokenStream(unittest.TestCase):
         stream = antlr3.CommonTokenStream(self.source)
 
         lt1 = stream.LT(1)
-        self.failUnlessEqual(lt1.type, 13)
+        self.assertEqual(lt1.type, 13)
 
 
     def testLT2BeyondEnd(self):
@@ -438,7 +438,7 @@ class TestCommonTokenStream(unittest.TestCase):
         stream = antlr3.CommonTokenStream(self.source)
 
         lt1 = stream.LT(2)
-        self.failUnlessEqual(lt1.type, antlr3.EOF)
+        self.assertEqual(lt1.type, antlr3.EOF)
 
 
     # not yet implemented
@@ -458,7 +458,7 @@ class TestCommonTokenStream(unittest.TestCase):
         stream.consume()
 
         lt1 = stream.LT(-1)
-        self.failUnlessEqual(lt1.type, 12)
+        self.assertEqual(lt1.type, 12)
 
 
     def testLB1(self):
@@ -476,7 +476,7 @@ class TestCommonTokenStream(unittest.TestCase):
         stream.fillBuffer()
         stream.consume()
 
-        self.failUnlessEqual(stream.LB(1).type, 12)
+        self.assertEqual(stream.LB(1).type, 12)
 
 
     def testLTZero(self):
@@ -493,7 +493,7 @@ class TestCommonTokenStream(unittest.TestCase):
         stream = antlr3.CommonTokenStream(self.source)
 
         lt1 = stream.LT(0)
-        self.failUnless(lt1 is None)
+        self.assertTrue(lt1 is None)
 
 
     def testLBBeyondBegin(self):
@@ -516,11 +516,11 @@ class TestCommonTokenStream(unittest.TestCase):
             )
 
         stream = antlr3.CommonTokenStream(self.source)
-        self.failUnless(stream.LB(1) is None)
+        self.assertTrue(stream.LB(1) is None)
 
         stream.consume()
         stream.consume()
-        self.failUnless(stream.LB(3) is None)
+        self.assertTrue(stream.LB(3) is None)
 
 
     def testFillBuffer(self):
@@ -545,10 +545,10 @@ class TestCommonTokenStream(unittest.TestCase):
         stream = antlr3.CommonTokenStream(self.source)
         stream.fillBuffer()
 
-        self.failUnlessEqual(len(stream.tokens), 3)
-        self.failUnlessEqual(stream.tokens[0].type, 12)
-        self.failUnlessEqual(stream.tokens[1].type, 13)
-        self.failUnlessEqual(stream.tokens[2].type, 14)
+        self.assertEqual(len(stream.tokens), 3)
+        self.assertEqual(stream.tokens[0].type, 12)
+        self.assertEqual(stream.tokens[1].type, 13)
+        self.assertEqual(stream.tokens[2].type, 14)
 
 
     def testConsume(self):
@@ -567,16 +567,16 @@ class TestCommonTokenStream(unittest.TestCase):
             )
 
         stream = antlr3.CommonTokenStream(self.source)
-        self.failUnlessEqual(stream.LA(1), 12)
+        self.assertEqual(stream.LA(1), 12)
 
         stream.consume()
-        self.failUnlessEqual(stream.LA(1), 13)
+        self.assertEqual(stream.LA(1), 13)
 
         stream.consume()
-        self.failUnlessEqual(stream.LA(1), antlr3.EOF)
+        self.assertEqual(stream.LA(1), antlr3.EOF)
 
         stream.consume()
-        self.failUnlessEqual(stream.LA(1), antlr3.EOF)
+        self.assertEqual(stream.LA(1), antlr3.EOF)
 
 
     def testSeek(self):
@@ -595,13 +595,13 @@ class TestCommonTokenStream(unittest.TestCase):
             )
 
         stream = antlr3.CommonTokenStream(self.source)
-        self.failUnlessEqual(stream.LA(1), 12)
+        self.assertEqual(stream.LA(1), 12)
 
         stream.seek(2)
-        self.failUnlessEqual(stream.LA(1), antlr3.EOF)
+        self.assertEqual(stream.LA(1), antlr3.EOF)
 
         stream.seek(0)
-        self.failUnlessEqual(stream.LA(1), 12)
+        self.assertEqual(stream.LA(1), 12)
 
 
     def testMarkRewind(self):
@@ -628,7 +628,7 @@ class TestCommonTokenStream(unittest.TestCase):
         stream.consume()
         stream.rewind(marker)
 
-        self.failUnlessEqual(stream.LA(1), 13)
+        self.assertEqual(stream.LA(1), 13)
 
 
     def testToString(self):

--- a/runtime/Python/unittests/testtree.py
+++ b/runtime/Python/unittests/testtree.py
@@ -27,11 +27,11 @@ class TestTreeNodeStream(unittest.TestCase):
         stream = self.newStream(t)
         expecting = "101"
         found = self.toNodesOnlyString(stream)
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
         expecting = "101"
         found = str(stream)
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
 
     def testTwoChildrenOfNilRoot(self):
@@ -76,11 +76,11 @@ class TestTreeNodeStream(unittest.TestCase):
         stream = self.newStream(t)
         expecting = "101 102 103 104"
         found = self.toNodesOnlyString(stream)
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
         expecting = "101 2 102 2 103 3 104 3"
         found = str(stream)
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
 
     def testList(self):
@@ -99,11 +99,11 @@ class TestTreeNodeStream(unittest.TestCase):
         stream = CommonTreeNodeStream(root)
         expecting = "101 102 103 104 105"
         found = self.toNodesOnlyString(stream)
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
         expecting = "101 2 102 2 103 3 104 3 105"
         found = str(stream)
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
 
     def testFlatList(self):
@@ -116,11 +116,11 @@ class TestTreeNodeStream(unittest.TestCase):
         stream = CommonTreeNodeStream(root)
         expecting = "101 102 103"
         found = self.toNodesOnlyString(stream)
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
         expecting = "101 102 103"
         found = str(stream)
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
 
     def testListWithOneNode(self):
@@ -131,11 +131,11 @@ class TestTreeNodeStream(unittest.TestCase):
         stream = CommonTreeNodeStream(root)
         expecting = "101"
         found = self.toNodesOnlyString(stream)
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
         expecting = "101"
         found = str(stream)
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
 
     def testAoverB(self):
@@ -145,11 +145,11 @@ class TestTreeNodeStream(unittest.TestCase):
         stream = self.newStream(t)
         expecting = "101 102"
         found = self.toNodesOnlyString(stream)
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
         expecting = "101 2 102 3"
         found = str(stream)
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
 
     def testLT(self):
@@ -160,17 +160,17 @@ class TestTreeNodeStream(unittest.TestCase):
         t.addChild(CommonTree(CommonToken(104)))
 
         stream = self.newStream(t)
-        self.failUnlessEqual(101, stream.LT(1).getType())
-        self.failUnlessEqual(DOWN, stream.LT(2).getType())
-        self.failUnlessEqual(102, stream.LT(3).getType())
-        self.failUnlessEqual(DOWN, stream.LT(4).getType())
-        self.failUnlessEqual(103, stream.LT(5).getType())
-        self.failUnlessEqual(UP, stream.LT(6).getType())
-        self.failUnlessEqual(104, stream.LT(7).getType())
-        self.failUnlessEqual(UP, stream.LT(8).getType())
-        self.failUnlessEqual(EOF, stream.LT(9).getType())
+        self.assertEqual(101, stream.LT(1).getType())
+        self.assertEqual(DOWN, stream.LT(2).getType())
+        self.assertEqual(102, stream.LT(3).getType())
+        self.assertEqual(DOWN, stream.LT(4).getType())
+        self.assertEqual(103, stream.LT(5).getType())
+        self.assertEqual(UP, stream.LT(6).getType())
+        self.assertEqual(104, stream.LT(7).getType())
+        self.assertEqual(UP, stream.LT(8).getType())
+        self.assertEqual(EOF, stream.LT(9).getType())
         # check way ahead
-        self.failUnlessEqual(EOF, stream.LT(100).getType())
+        self.assertEqual(EOF, stream.LT(100).getType())
 
 
     def testMarkRewindEntire(self):
@@ -193,8 +193,8 @@ class TestTreeNodeStream(unittest.TestCase):
             stream.LT(1)
             stream.consume()
 
-        self.failUnlessEqual(EOF, stream.LT(1).getType())
-        self.failUnlessEqual(UP, stream.LT(-1).getType())  #TODO: remove?
+        self.assertEqual(EOF, stream.LT(1).getType())
+        self.assertEqual(UP, stream.LT(-1).getType())  #TODO: remove?
         stream.rewind(m)      # REWIND
 
         # consume til end again :)
@@ -202,8 +202,8 @@ class TestTreeNodeStream(unittest.TestCase):
             stream.LT(1)
             stream.consume()
 
-        self.failUnlessEqual(EOF, stream.LT(1).getType())
-        self.failUnlessEqual(UP, stream.LT(-1).getType())  #TODO: remove?
+        self.assertEqual(EOF, stream.LT(1).getType())
+        self.assertEqual(UP, stream.LT(-1).getType())  #TODO: remove?
 
 
     def testMarkRewindInMiddle(self):
@@ -225,7 +225,7 @@ class TestTreeNodeStream(unittest.TestCase):
             #System.out.println(tream.LT(1).getType())
             stream.consume()
 
-        self.failUnlessEqual(107, stream.LT(1).getType())
+        self.assertEqual(107, stream.LT(1).getType())
         m = stream.mark() # MARK
         stream.consume() # consume 107
         stream.consume() # consume UP
@@ -233,21 +233,21 @@ class TestTreeNodeStream(unittest.TestCase):
         stream.consume() # consume 104
         stream.rewind(m)      # REWIND
 
-        self.failUnlessEqual(107, stream.LT(1).getType())
+        self.assertEqual(107, stream.LT(1).getType())
         stream.consume()
-        self.failUnlessEqual(UP, stream.LT(1).getType())
+        self.assertEqual(UP, stream.LT(1).getType())
         stream.consume()
-        self.failUnlessEqual(UP, stream.LT(1).getType())
+        self.assertEqual(UP, stream.LT(1).getType())
         stream.consume()
-        self.failUnlessEqual(104, stream.LT(1).getType())
+        self.assertEqual(104, stream.LT(1).getType())
         stream.consume()
         # now we're past rewind position
-        self.failUnlessEqual(105, stream.LT(1).getType())
+        self.assertEqual(105, stream.LT(1).getType())
         stream.consume()
-        self.failUnlessEqual(UP, stream.LT(1).getType())
+        self.assertEqual(UP, stream.LT(1).getType())
         stream.consume()
-        self.failUnlessEqual(EOF, stream.LT(1).getType())
-        self.failUnlessEqual(UP, stream.LT(-1).getType())
+        self.assertEqual(EOF, stream.LT(1).getType())
+        self.assertEqual(UP, stream.LT(-1).getType())
 
 
     def testMarkRewindNested(self):
@@ -274,19 +274,19 @@ class TestTreeNodeStream(unittest.TestCase):
         stream.consume() # consume 103
         stream.consume() # consume 106
         stream.rewind(m2)      # REWIND to 102
-        self.failUnlessEqual(102, stream.LT(1).getType())
+        self.assertEqual(102, stream.LT(1).getType())
         stream.consume()
-        self.failUnlessEqual(DOWN, stream.LT(1).getType())
+        self.assertEqual(DOWN, stream.LT(1).getType())
         stream.consume()
         # stop at 103 and rewind to start
         stream.rewind(m) # REWIND to 101
-        self.failUnlessEqual(101, stream.LT(1).getType())
+        self.assertEqual(101, stream.LT(1).getType())
         stream.consume()
-        self.failUnlessEqual(DOWN, stream.LT(1).getType())
+        self.assertEqual(DOWN, stream.LT(1).getType())
         stream.consume()
-        self.failUnlessEqual(102, stream.LT(1).getType())
+        self.assertEqual(102, stream.LT(1).getType())
         stream.consume()
-        self.failUnlessEqual(DOWN, stream.LT(1).getType())
+        self.assertEqual(DOWN, stream.LT(1).getType())
 
 
     def testSeek(self):
@@ -308,11 +308,11 @@ class TestTreeNodeStream(unittest.TestCase):
         stream.consume() # consume DN
         stream.consume() # consume 102
         stream.seek(7)   # seek to 107
-        self.failUnlessEqual(107, stream.LT(1).getType())
+        self.assertEqual(107, stream.LT(1).getType())
         stream.consume() # consume 107
         stream.consume() # consume UP
         stream.consume() # consume UP
-        self.failUnlessEqual(104, stream.LT(1).getType())
+        self.assertEqual(104, stream.LT(1).getType())
 
 
     def testSeekFromStart(self):
@@ -331,11 +331,11 @@ class TestTreeNodeStream(unittest.TestCase):
 
         stream = CommonTreeNodeStream(r0)
         stream.seek(7)   # seek to 107
-        self.failUnlessEqual(107, stream.LT(1).getType())
+        self.assertEqual(107, stream.LT(1).getType())
         stream.consume() # consume 107
         stream.consume() # consume UP
         stream.consume() # consume UP
-        self.failUnlessEqual(104, stream.LT(1).getType())
+        self.assertEqual(104, stream.LT(1).getType())
 
 
     def testReset(self):
@@ -412,7 +412,7 @@ class TestCommonTreeNodeStream(unittest.TestCase):
         stream = CommonTreeNodeStream(r0)
         expecting = "101 2 102 2 103 3 104 2 105 3 106 2 107 3 108 109 3"
         found = str(stream)
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
         # Assume we want to hit node 107 and then "call 102" then return
 
@@ -422,18 +422,18 @@ class TestCommonTreeNodeStream(unittest.TestCase):
             stream.consume()
 
         # CALL 102
-        self.failUnlessEqual(107, stream.LT(1).getType())
+        self.assertEqual(107, stream.LT(1).getType())
         stream.push(indexOf102)
-        self.failUnlessEqual(102, stream.LT(1).getType())
+        self.assertEqual(102, stream.LT(1).getType())
         stream.consume() # consume 102
-        self.failUnlessEqual(DOWN, stream.LT(1).getType())
+        self.assertEqual(DOWN, stream.LT(1).getType())
         stream.consume() # consume DN
-        self.failUnlessEqual(103, stream.LT(1).getType())
+        self.assertEqual(103, stream.LT(1).getType())
         stream.consume() # consume 103
-        self.failUnlessEqual(UP, stream.LT(1).getType())
+        self.assertEqual(UP, stream.LT(1).getType())
         # RETURN
         stream.pop()
-        self.failUnlessEqual(107, stream.LT(1).getType())
+        self.assertEqual(107, stream.LT(1).getType())
 
 
     def testNestedPushPop(self):
@@ -463,33 +463,33 @@ class TestCommonTreeNodeStream(unittest.TestCase):
         for _ in range(indexOf107): # consume til 107 node
             stream.consume()
 
-        self.failUnlessEqual(107, stream.LT(1).getType())
+        self.assertEqual(107, stream.LT(1).getType())
         # CALL 102
         stream.push(indexOf102)
-        self.failUnlessEqual(102, stream.LT(1).getType())
+        self.assertEqual(102, stream.LT(1).getType())
         stream.consume() # consume 102
-        self.failUnlessEqual(DOWN, stream.LT(1).getType())
+        self.assertEqual(DOWN, stream.LT(1).getType())
         stream.consume() # consume DN
-        self.failUnlessEqual(103, stream.LT(1).getType())
+        self.assertEqual(103, stream.LT(1).getType())
         stream.consume() # consume 103
 
         # CALL 104
         indexOf104 = 6
         stream.push(indexOf104)
-        self.failUnlessEqual(104, stream.LT(1).getType())
+        self.assertEqual(104, stream.LT(1).getType())
         stream.consume() # consume 102
-        self.failUnlessEqual(DOWN, stream.LT(1).getType())
+        self.assertEqual(DOWN, stream.LT(1).getType())
         stream.consume() # consume DN
-        self.failUnlessEqual(105, stream.LT(1).getType())
+        self.assertEqual(105, stream.LT(1).getType())
         stream.consume() # consume 103
-        self.failUnlessEqual(UP, stream.LT(1).getType())
+        self.assertEqual(UP, stream.LT(1).getType())
         # RETURN (to UP node in 102 subtree)
         stream.pop()
 
-        self.failUnlessEqual(UP, stream.LT(1).getType())
+        self.assertEqual(UP, stream.LT(1).getType())
         # RETURN (to empty stack)
         stream.pop()
-        self.failUnlessEqual(107, stream.LT(1).getType())
+        self.assertEqual(107, stream.LT(1).getType())
 
 
     def testPushPopFromEOF(self):
@@ -516,33 +516,33 @@ class TestCommonTreeNodeStream(unittest.TestCase):
 
         indexOf102 = 2
         indexOf104 = 6
-        self.failUnlessEqual(EOF, stream.LT(1).getType())
+        self.assertEqual(EOF, stream.LT(1).getType())
 
         # CALL 102
         stream.push(indexOf102)
-        self.failUnlessEqual(102, stream.LT(1).getType())
+        self.assertEqual(102, stream.LT(1).getType())
         stream.consume() # consume 102
-        self.failUnlessEqual(DOWN, stream.LT(1).getType())
+        self.assertEqual(DOWN, stream.LT(1).getType())
         stream.consume() # consume DN
-        self.failUnlessEqual(103, stream.LT(1).getType())
+        self.assertEqual(103, stream.LT(1).getType())
         stream.consume() # consume 103
-        self.failUnlessEqual(UP, stream.LT(1).getType())
+        self.assertEqual(UP, stream.LT(1).getType())
         # RETURN (to empty stack)
         stream.pop()
-        self.failUnlessEqual(EOF, stream.LT(1).getType())
+        self.assertEqual(EOF, stream.LT(1).getType())
 
         # CALL 104
         stream.push(indexOf104)
-        self.failUnlessEqual(104, stream.LT(1).getType())
+        self.assertEqual(104, stream.LT(1).getType())
         stream.consume() # consume 102
-        self.failUnlessEqual(DOWN, stream.LT(1).getType())
+        self.assertEqual(DOWN, stream.LT(1).getType())
         stream.consume() # consume DN
-        self.failUnlessEqual(105, stream.LT(1).getType())
+        self.assertEqual(105, stream.LT(1).getType())
         stream.consume() # consume 103
-        self.failUnlessEqual(UP, stream.LT(1).getType())
+        self.assertEqual(UP, stream.LT(1).getType())
         # RETURN (to empty stack)
         stream.pop()
-        self.failUnlessEqual(EOF, stream.LT(1).getType())
+        self.assertEqual(EOF, stream.LT(1).getType())
 
 
 class TestCommonTree(unittest.TestCase):
@@ -556,8 +556,8 @@ class TestCommonTree(unittest.TestCase):
 
     def testSingleNode(self):
         t = CommonTree(CommonToken(101))
-        self.failUnless(t.parent is None)
-        self.failUnlessEqual(-1, t.childIndex)
+        self.assertTrue(t.parent is None)
+        self.assertEqual(-1, t.childIndex)
 
 
     def test4Nodes(self):
@@ -567,8 +567,8 @@ class TestCommonTree(unittest.TestCase):
         r0.getChild(0).addChild(CommonTree(CommonToken(103)))
         r0.addChild(CommonTree(CommonToken(104)))
 
-        self.failUnless(r0.parent is None)
-        self.failUnlessEqual(-1, r0.childIndex)
+        self.assertTrue(r0.parent is None)
+        self.assertEqual(-1, r0.childIndex)
 
 
     def testList(self):
@@ -581,14 +581,14 @@ class TestCommonTree(unittest.TestCase):
         c2=CommonTree(CommonToken(103))
         r0.addChild(c2)
 
-        self.failUnless(r0.parent is None)
-        self.failUnlessEqual(-1, r0.childIndex)
-        self.failUnlessEqual(r0, c0.parent)
-        self.failUnlessEqual(0, c0.childIndex)
-        self.failUnlessEqual(r0, c1.parent)
-        self.failUnlessEqual(1, c1.childIndex)
-        self.failUnlessEqual(r0, c2.parent)
-        self.failUnlessEqual(2, c2.childIndex)
+        self.assertTrue(r0.parent is None)
+        self.assertEqual(-1, r0.childIndex)
+        self.assertEqual(r0, c0.parent)
+        self.assertEqual(0, c0.childIndex)
+        self.assertEqual(r0, c1.parent)
+        self.assertEqual(1, c1.childIndex)
+        self.assertEqual(r0, c2.parent)
+        self.assertEqual(2, c2.childIndex)
 
 
     def testList2(self):
@@ -607,15 +607,15 @@ class TestCommonTree(unittest.TestCase):
 
         root.addChild(r0)
 
-        self.failUnless(root.parent is None)
-        self.failUnlessEqual(-1, root.childIndex)
+        self.assertTrue(root.parent is None)
+        self.assertEqual(-1, root.childIndex)
         # check children of root all point at root
-        self.failUnlessEqual(root, c0.parent)
-        self.failUnlessEqual(0, c0.childIndex)
-        self.failUnlessEqual(root, c0.parent)
-        self.failUnlessEqual(1, c1.childIndex)
-        self.failUnlessEqual(root, c0.parent)
-        self.failUnlessEqual(2, c2.childIndex)
+        self.assertEqual(root, c0.parent)
+        self.assertEqual(0, c0.childIndex)
+        self.assertEqual(root, c0.parent)
+        self.assertEqual(1, c1.childIndex)
+        self.assertEqual(root, c0.parent)
+        self.assertEqual(2, c2.childIndex)
 
 
     def testAddListToExistChildren(self):
@@ -635,15 +635,15 @@ class TestCommonTree(unittest.TestCase):
 
         root.addChild(r0)
 
-        self.failUnless(root.parent is None)
-        self.failUnlessEqual(-1, root.childIndex)
+        self.assertTrue(root.parent is None)
+        self.assertEqual(-1, root.childIndex)
         # check children of root all point at root
-        self.failUnlessEqual(root, c0.parent)
-        self.failUnlessEqual(1, c0.childIndex)
-        self.failUnlessEqual(root, c0.parent)
-        self.failUnlessEqual(2, c1.childIndex)
-        self.failUnlessEqual(root, c0.parent)
-        self.failUnlessEqual(3, c2.childIndex)
+        self.assertEqual(root, c0.parent)
+        self.assertEqual(1, c0.childIndex)
+        self.assertEqual(root, c0.parent)
+        self.assertEqual(2, c1.childIndex)
+        self.assertEqual(root, c0.parent)
+        self.assertEqual(3, c2.childIndex)
 
 
     def testDupTree(self):
@@ -660,8 +660,8 @@ class TestCommonTree(unittest.TestCase):
 
         dup = self.adaptor.dupTree(r0)
 
-        self.failUnless(dup.parent is None)
-        self.failUnlessEqual(-1, dup.childIndex)
+        self.assertTrue(dup.parent is None)
+        self.assertEqual(-1, dup.childIndex)
         dup.sanityCheckParentAndChildIndexes()
 
 
@@ -742,7 +742,7 @@ class TestCommonTree(unittest.TestCase):
         except IndexError:
         	error = True
 
-        self.failUnless(error)
+        self.assertTrue(error)
 
 
     def testReplaceWithOneChildren(self):
@@ -754,7 +754,7 @@ class TestCommonTree(unittest.TestCase):
         newChild = CommonTree(CommonToken(99, text="c"))
         t.replaceChildren(0, 0, newChild)
         expecting = "(a c)"
-        self.failUnlessEqual(expecting, t.toStringTree())
+        self.assertEqual(expecting, t.toStringTree())
         t.sanityCheckParentAndChildIndexes()
 
 
@@ -767,7 +767,7 @@ class TestCommonTree(unittest.TestCase):
         newChild = CommonTree(CommonToken(99, text="x"))
         t.replaceChildren(1, 1, newChild)
         expecting = "(a b x d)"
-        self.failUnlessEqual(expecting, t.toStringTree())
+        self.assertEqual(expecting, t.toStringTree())
         t.sanityCheckParentAndChildIndexes()
 
 
@@ -780,7 +780,7 @@ class TestCommonTree(unittest.TestCase):
         newChild = CommonTree(CommonToken(99, text="x"))
         t.replaceChildren(0, 0, newChild)
         expecting = "(a x c d)"
-        self.failUnlessEqual(expecting, t.toStringTree())
+        self.assertEqual(expecting, t.toStringTree())
         t.sanityCheckParentAndChildIndexes()
 
 
@@ -793,7 +793,7 @@ class TestCommonTree(unittest.TestCase):
         newChild = CommonTree(CommonToken(99, text="x"))
         t.replaceChildren(2, 2, newChild)
         expecting = "(a b c x)"
-        self.failUnlessEqual(expecting, t.toStringTree())
+        self.assertEqual(expecting, t.toStringTree())
         t.sanityCheckParentAndChildIndexes()
 
 
@@ -809,7 +809,7 @@ class TestCommonTree(unittest.TestCase):
 
         t.replaceChildren(0, 0, newChildren)
         expecting = "(a x y c d)"
-        self.failUnlessEqual(expecting, t.toStringTree())
+        self.assertEqual(expecting, t.toStringTree())
         t.sanityCheckParentAndChildIndexes()
 
 
@@ -825,7 +825,7 @@ class TestCommonTree(unittest.TestCase):
 
         t.replaceChildren(2, 2, newChildren)
         expecting = "(a b c x y)"
-        self.failUnlessEqual(expecting, t.toStringTree())
+        self.assertEqual(expecting, t.toStringTree())
         t.sanityCheckParentAndChildIndexes()
 
 
@@ -841,7 +841,7 @@ class TestCommonTree(unittest.TestCase):
 
         t.replaceChildren(1, 1, newChildren)
         expecting = "(a b x y d)"
-        self.failUnlessEqual(expecting, t.toStringTree())
+        self.assertEqual(expecting, t.toStringTree())
         t.sanityCheckParentAndChildIndexes()
 
 
@@ -855,7 +855,7 @@ class TestCommonTree(unittest.TestCase):
 
         t.replaceChildren(0, 1, newChild)
         expecting = "(a x d)"
-        self.failUnlessEqual(expecting, t.toStringTree())
+        self.assertEqual(expecting, t.toStringTree())
         t.sanityCheckParentAndChildIndexes()
 
 
@@ -869,7 +869,7 @@ class TestCommonTree(unittest.TestCase):
 
         t.replaceChildren(1, 2, newChild)
         expecting = "(a b x)"
-        self.failUnlessEqual(expecting, t.toStringTree())
+        self.assertEqual(expecting, t.toStringTree())
         t.sanityCheckParentAndChildIndexes()
 
 
@@ -883,7 +883,7 @@ class TestCommonTree(unittest.TestCase):
 
         t.replaceChildren(0, 2, newChild)
         expecting = "(a x)"
-        self.failUnlessEqual(expecting, t.toStringTree())
+        self.assertEqual(expecting, t.toStringTree())
         t.sanityCheckParentAndChildIndexes()
 
 
@@ -899,7 +899,7 @@ class TestCommonTree(unittest.TestCase):
 
         t.replaceChildren(0, 2, newChildren)
         expecting = "(a x y)"
-        self.failUnlessEqual(expecting, t.toStringTree())
+        self.assertEqual(expecting, t.toStringTree())
         t.sanityCheckParentAndChildIndexes()
 
 

--- a/runtime/Python/unittests/testtreewizard.py
+++ b/runtime/Python/unittests/testtreewizard.py
@@ -18,16 +18,16 @@ class TestComputeTokenTypes(unittest.TestCase):
         """computeTokenTypes(None) -> {}"""
 
         typeMap = computeTokenTypes(None)
-        self.failUnless(isinstance(typeMap, dict))
-        self.failUnlessEqual(typeMap, {})
+        self.assertTrue(isinstance(typeMap, dict))
+        self.assertEqual(typeMap, {})
 
 
     def testList(self):
         """computeTokenTypes(['a', 'b']) -> { 'a': 0, 'b': 1 }"""
 
         typeMap = computeTokenTypes(['a', 'b'])
-        self.failUnless(isinstance(typeMap, dict))
-        self.failUnlessEqual(typeMap, { 'a': 0, 'b': 1 })
+        self.assertTrue(isinstance(typeMap, dict))
+        self.assertEqual(typeMap, { 'a': 0, 'b': 1 })
 
 
 class TestTreePatternLexer(unittest.TestCase):
@@ -38,9 +38,9 @@ class TestTreePatternLexer(unittest.TestCase):
 
         lexer = TreePatternLexer('(')
         type = lexer.nextToken()
-        self.failUnlessEqual(type, BEGIN)
-        self.failUnlessEqual(lexer.sval, '')
-        self.failUnlessEqual(lexer.error, False)
+        self.assertEqual(type, BEGIN)
+        self.assertEqual(lexer.sval, '')
+        self.assertEqual(lexer.error, False)
 
 
     def testEnd(self):
@@ -48,9 +48,9 @@ class TestTreePatternLexer(unittest.TestCase):
 
         lexer = TreePatternLexer(')')
         type = lexer.nextToken()
-        self.failUnlessEqual(type, END)
-        self.failUnlessEqual(lexer.sval, '')
-        self.failUnlessEqual(lexer.error, False)
+        self.assertEqual(type, END)
+        self.assertEqual(lexer.sval, '')
+        self.assertEqual(lexer.error, False)
 
 
     def testPercent(self):
@@ -58,9 +58,9 @@ class TestTreePatternLexer(unittest.TestCase):
 
         lexer = TreePatternLexer('%')
         type = lexer.nextToken()
-        self.failUnlessEqual(type, PERCENT)
-        self.failUnlessEqual(lexer.sval, '')
-        self.failUnlessEqual(lexer.error, False)
+        self.assertEqual(type, PERCENT)
+        self.assertEqual(lexer.sval, '')
+        self.assertEqual(lexer.error, False)
 
 
     def testDot(self):
@@ -68,9 +68,9 @@ class TestTreePatternLexer(unittest.TestCase):
 
         lexer = TreePatternLexer('.')
         type = lexer.nextToken()
-        self.failUnlessEqual(type, DOT)
-        self.failUnlessEqual(lexer.sval, '')
-        self.failUnlessEqual(lexer.error, False)
+        self.assertEqual(type, DOT)
+        self.assertEqual(lexer.sval, '')
+        self.assertEqual(lexer.error, False)
 
 
     def testColon(self):
@@ -78,9 +78,9 @@ class TestTreePatternLexer(unittest.TestCase):
 
         lexer = TreePatternLexer(':')
         type = lexer.nextToken()
-        self.failUnlessEqual(type, COLON)
-        self.failUnlessEqual(lexer.sval, '')
-        self.failUnlessEqual(lexer.error, False)
+        self.assertEqual(type, COLON)
+        self.assertEqual(lexer.sval, '')
+        self.assertEqual(lexer.error, False)
 
 
     def testEOF(self):
@@ -88,9 +88,9 @@ class TestTreePatternLexer(unittest.TestCase):
 
         lexer = TreePatternLexer('  \n \r \t ')
         type = lexer.nextToken()
-        self.failUnlessEqual(type, EOF)
-        self.failUnlessEqual(lexer.sval, '')
-        self.failUnlessEqual(lexer.error, False)
+        self.assertEqual(type, EOF)
+        self.assertEqual(lexer.sval, '')
+        self.assertEqual(lexer.error, False)
 
 
     def testID(self):
@@ -98,9 +98,9 @@ class TestTreePatternLexer(unittest.TestCase):
 
         lexer = TreePatternLexer('_foo12_bar')
         type = lexer.nextToken()
-        self.failUnlessEqual(type, ID)
-        self.failUnlessEqual(lexer.sval, '_foo12_bar')
-        self.failUnlessEqual(lexer.error, False)
+        self.assertEqual(type, ID)
+        self.assertEqual(lexer.sval, '_foo12_bar')
+        self.assertEqual(lexer.error, False)
 
 
     def testARG(self):
@@ -108,9 +108,9 @@ class TestTreePatternLexer(unittest.TestCase):
 
         lexer = TreePatternLexer('[ \\]bla\\n]')
         type = lexer.nextToken()
-        self.failUnlessEqual(type, ARG)
-        self.failUnlessEqual(lexer.sval, ' ]bla\\n')
-        self.failUnlessEqual(lexer.error, False)
+        self.assertEqual(type, ARG)
+        self.assertEqual(lexer.sval, ' ]bla\\n')
+        self.assertEqual(lexer.error, False)
 
 
     def testError(self):
@@ -118,9 +118,9 @@ class TestTreePatternLexer(unittest.TestCase):
 
         lexer = TreePatternLexer('1')
         type = lexer.nextToken()
-        self.failUnlessEqual(type, EOF)
-        self.failUnlessEqual(lexer.sval, '')
-        self.failUnlessEqual(lexer.error, True)
+        self.assertEqual(type, EOF)
+        self.assertEqual(lexer.sval, '')
+        self.assertEqual(lexer.error, True)
 
 
 class TestTreePatternParser(unittest.TestCase):
@@ -146,9 +146,9 @@ class TestTreePatternParser(unittest.TestCase):
         lexer = TreePatternLexer('ID')
         parser = TreePatternParser(lexer, self.wizard, self.adaptor)
         tree = parser.pattern()
-        self.failUnless(isinstance(tree, CommonTree))
-        self.failUnlessEqual(tree.getType(), 10)
-        self.failUnlessEqual(tree.getText(), 'ID')
+        self.assertTrue(isinstance(tree, CommonTree))
+        self.assertEqual(tree.getType(), 10)
+        self.assertEqual(tree.getText(), 'ID')
 
 
     def testSingleNodeWithArg(self):
@@ -156,9 +156,9 @@ class TestTreePatternParser(unittest.TestCase):
         lexer = TreePatternLexer('ID[foo]')
         parser = TreePatternParser(lexer, self.wizard, self.adaptor)
         tree = parser.pattern()
-        self.failUnless(isinstance(tree, CommonTree))
-        self.failUnlessEqual(tree.getType(), 10)
-        self.failUnlessEqual(tree.getText(), 'foo')
+        self.assertTrue(isinstance(tree, CommonTree))
+        self.assertEqual(tree.getType(), 10)
+        self.assertEqual(tree.getText(), 'foo')
 
 
     def testSingleLevelTree(self):
@@ -166,12 +166,12 @@ class TestTreePatternParser(unittest.TestCase):
         lexer = TreePatternLexer('(A B)')
         parser = TreePatternParser(lexer, self.wizard, self.adaptor)
         tree = parser.pattern()
-        self.failUnless(isinstance(tree, CommonTree))
-        self.failUnlessEqual(tree.getType(), 5)
-        self.failUnlessEqual(tree.getText(), 'A')
-        self.failUnlessEqual(tree.getChildCount(), 1)
-        self.failUnlessEqual(tree.getChild(0).getType(), 6)
-        self.failUnlessEqual(tree.getChild(0).getText(), 'B')
+        self.assertTrue(isinstance(tree, CommonTree))
+        self.assertEqual(tree.getType(), 5)
+        self.assertEqual(tree.getText(), 'A')
+        self.assertEqual(tree.getChildCount(), 1)
+        self.assertEqual(tree.getChild(0).getType(), 6)
+        self.assertEqual(tree.getChild(0).getText(), 'B')
 
 
     def testNil(self):
@@ -179,9 +179,9 @@ class TestTreePatternParser(unittest.TestCase):
         lexer = TreePatternLexer('nil')
         parser = TreePatternParser(lexer, self.wizard, self.adaptor)
         tree = parser.pattern()
-        self.failUnless(isinstance(tree, CommonTree))
-        self.failUnlessEqual(tree.getType(), 0)
-        self.failUnlessEqual(tree.getText(), None)
+        self.assertTrue(isinstance(tree, CommonTree))
+        self.assertEqual(tree.getType(), 0)
+        self.assertEqual(tree.getText(), None)
 
 
     def testWildcard(self):
@@ -189,7 +189,7 @@ class TestTreePatternParser(unittest.TestCase):
         lexer = TreePatternLexer('(.)')
         parser = TreePatternParser(lexer, self.wizard, self.adaptor)
         tree = parser.pattern()
-        self.failUnless(isinstance(tree, WildcardTreePattern))
+        self.assertTrue(isinstance(tree, WildcardTreePattern))
 
 
     def testLabel(self):
@@ -197,8 +197,8 @@ class TestTreePatternParser(unittest.TestCase):
         lexer = TreePatternLexer('(%a:A)')
         parser = TreePatternParser(lexer, self.wizard, TreePatternTreeAdaptor())
         tree = parser.pattern()
-        self.failUnless(isinstance(tree, TreePattern))
-        self.failUnlessEqual(tree.label, 'a')
+        self.assertTrue(isinstance(tree, TreePattern))
+        self.assertEqual(tree.label, 'a')
 
 
     def testError1(self):
@@ -206,7 +206,7 @@ class TestTreePatternParser(unittest.TestCase):
         lexer = TreePatternLexer(')')
         parser = TreePatternParser(lexer, self.wizard, self.adaptor)
         tree = parser.pattern()
-        self.failUnless(tree is None)
+        self.assertTrue(tree is None)
 
 
     def testError2(self):
@@ -214,7 +214,7 @@ class TestTreePatternParser(unittest.TestCase):
         lexer = TreePatternLexer('()')
         parser = TreePatternParser(lexer, self.wizard, self.adaptor)
         tree = parser.pattern()
-        self.failUnless(tree is None)
+        self.assertTrue(tree is None)
 
 
     def testError3(self):
@@ -222,7 +222,7 @@ class TestTreePatternParser(unittest.TestCase):
         lexer = TreePatternLexer('(A ])')
         parser = TreePatternParser(lexer, self.wizard, self.adaptor)
         tree = parser.pattern()
-        self.failUnless(tree is None)
+        self.assertTrue(tree is None)
 
 
 class TestTreeWizard(unittest.TestCase):
@@ -250,8 +250,8 @@ class TestTreeWizard(unittest.TestCase):
             tokenNames=['a', 'b']
             )
 
-        self.failUnless(wiz.adaptor is self.adaptor)
-        self.failUnlessEqual(
+        self.assertTrue(wiz.adaptor is self.adaptor)
+        self.assertEqual(
             wiz.tokenNameToTypeMap,
             { 'a': 0, 'b': 1 }
             )
@@ -265,17 +265,17 @@ class TestTreeWizard(unittest.TestCase):
             tokenNames=self.tokens
             )
 
-        self.failUnlessEqual(
+        self.assertEqual(
             wiz.getTokenType('A'),
             5
             )
 
-        self.failUnlessEqual(
+        self.assertEqual(
             wiz.getTokenType('VAR'),
             11
             )
 
-        self.failUnlessEqual(
+        self.assertEqual(
             wiz.getTokenType('invalid'),
             INVALID_TOKEN_TYPE
             )
@@ -285,7 +285,7 @@ class TestTreeWizard(unittest.TestCase):
         t = wiz.create("ID")
         found = t.toStringTree()
         expecting = "ID"
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
 
     def testSingleNodeWithArg(self):
@@ -293,7 +293,7 @@ class TestTreeWizard(unittest.TestCase):
         t = wiz.create("ID[foo]")
         found = t.toStringTree()
         expecting = "foo"
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
 
     def testSingleNodeTree(self):
@@ -301,7 +301,7 @@ class TestTreeWizard(unittest.TestCase):
         t = wiz.create("(A)")
         found = t.toStringTree()
         expecting = "A"
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
 
     def testSingleLevelTree(self):
@@ -309,7 +309,7 @@ class TestTreeWizard(unittest.TestCase):
         t = wiz.create("(A B C D)")
         found = t.toStringTree()
         expecting = "(A B C D)"
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
 
     def testListTree(self):
@@ -317,13 +317,13 @@ class TestTreeWizard(unittest.TestCase):
         t = wiz.create("(nil A B C)")
         found = t.toStringTree()
         expecting = "A B C"
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
 
     def testInvalidListTree(self):
         wiz = TreeWizard(self.adaptor, self.tokens)
         t = wiz.create("A B C")
-        self.failUnless(t is None)
+        self.assertTrue(t is None)
 
 
     def testDoubleLevelTree(self):
@@ -331,7 +331,7 @@ class TestTreeWizard(unittest.TestCase):
         t = wiz.create("(A (B C) (B D) E)")
         found = t.toStringTree()
         expecting = "(A (B C) (B D) E)"
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
 
     def __simplifyIndexMap(self, indexMap):
@@ -346,7 +346,7 @@ class TestTreeWizard(unittest.TestCase):
         indexMap = wiz.index(tree)
         found = self.__simplifyIndexMap(indexMap)
         expecting = { 10: ["ID"] }
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
 
     def testNoRepeatsIndex(self):
@@ -355,7 +355,7 @@ class TestTreeWizard(unittest.TestCase):
         indexMap = wiz.index(tree)
         found = self.__simplifyIndexMap(indexMap)
         expecting = { 8:['D'], 6:['B'], 7:['C'], 5:['A'] }
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
 
     def testRepeatsIndex(self):
@@ -364,7 +364,7 @@ class TestTreeWizard(unittest.TestCase):
         indexMap = wiz.index(tree)
         found = self.__simplifyIndexMap(indexMap)
         expecting = { 8: ['D', 'D'], 6: ['B', 'B', 'B'], 7: ['C'], 5: ['A', 'A'] }
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
 
     def testNoRepeatsVisit(self):
@@ -378,7 +378,7 @@ class TestTreeWizard(unittest.TestCase):
         wiz.visit(tree, wiz.getTokenType("B"), visitor)
 
         expecting = ['B']
-        self.failUnlessEqual(expecting, elements)
+        self.assertEqual(expecting, elements)
 
 
     def testNoRepeatsVisit2(self):
@@ -392,7 +392,7 @@ class TestTreeWizard(unittest.TestCase):
         wiz.visit(tree, wiz.getTokenType("C"), visitor)
 
         expecting = ['C']
-        self.failUnlessEqual(expecting, elements)
+        self.assertEqual(expecting, elements)
 
 
     def testRepeatsVisit(self):
@@ -406,7 +406,7 @@ class TestTreeWizard(unittest.TestCase):
         wiz.visit(tree, wiz.getTokenType("B"), visitor)
 
         expecting = ['B', 'B', 'B']
-        self.failUnlessEqual(expecting, elements)
+        self.assertEqual(expecting, elements)
 
 
     def testRepeatsVisit2(self):
@@ -420,7 +420,7 @@ class TestTreeWizard(unittest.TestCase):
         wiz.visit(tree, wiz.getTokenType("A"), visitor)
 
         expecting = ['A', 'A']
-        self.failUnlessEqual(expecting, elements)
+        self.assertEqual(expecting, elements)
 
 
     def testRepeatsVisitWithContext(self):
@@ -434,7 +434,7 @@ class TestTreeWizard(unittest.TestCase):
         wiz.visit(tree, wiz.getTokenType("B"), visitor)
 
         expecting = ['B@A[0]', 'B@A[1]', 'B@A[2]']
-        self.failUnlessEqual(expecting, elements)
+        self.assertEqual(expecting, elements)
 
 
     def testRepeatsVisitWithNullParentAndContext(self):
@@ -451,7 +451,7 @@ class TestTreeWizard(unittest.TestCase):
         wiz.visit(tree, wiz.getTokenType("A"), visitor)
 
         expecting = ['A@nil[0]', 'A@A[1]']
-        self.failUnlessEqual(expecting, elements)
+        self.assertEqual(expecting, elements)
 
 
     def testVisitPattern(self):
@@ -467,7 +467,7 @@ class TestTreeWizard(unittest.TestCase):
         wiz.visit(tree, '(A B)', visitor)
 
         expecting = ['A'] # shouldn't match overall root, just (A B)
-        self.failUnlessEqual(expecting, elements)
+        self.assertEqual(expecting, elements)
 
 
     def testVisitPatternMultiple(self):
@@ -484,7 +484,7 @@ class TestTreeWizard(unittest.TestCase):
         wiz.visit(tree, '(A B)', visitor)
 
         expecting = ['A@A[2]', 'A@D[0]']
-        self.failUnlessEqual(expecting, elements)
+        self.assertEqual(expecting, elements)
 
 
     def testVisitPatternMultipleWithLabels(self):
@@ -506,56 +506,56 @@ class TestTreeWizard(unittest.TestCase):
         wiz.visit(tree, '(%a:A %b:B)', visitor)
 
         expecting = ['foo@A[2]foo&bar', 'big@D[0]big&dog']
-        self.failUnlessEqual(expecting, elements)
+        self.assertEqual(expecting, elements)
 
 
     def testParse(self):
         wiz = TreeWizard(self.adaptor, self.tokens)
         t = wiz.create("(A B C)")
         valid = wiz.parse(t, "(A B C)")
-        self.failUnless(valid)
+        self.assertTrue(valid)
 
 
     def testParseSingleNode(self):
         wiz = TreeWizard(self.adaptor, self.tokens)
         t = wiz.create("A")
         valid = wiz.parse(t, "A")
-        self.failUnless(valid)
+        self.assertTrue(valid)
 
 
     def testParseSingleNodeFails(self):
         wiz = TreeWizard(self.adaptor, self.tokens)
         t = wiz.create("A")
         valid = wiz.parse(t, "B")
-        self.failUnless(not valid)
+        self.assertTrue(not valid)
 
 
     def testParseFlatTree(self):
         wiz = TreeWizard(self.adaptor, self.tokens)
         t = wiz.create("(nil A B C)")
         valid = wiz.parse(t, "(nil A B C)")
-        self.failUnless(valid)
+        self.assertTrue(valid)
 
 
     def testParseFlatTreeFails(self):
         wiz = TreeWizard(self.adaptor, self.tokens)
         t = wiz.create("(nil A B C)")
         valid = wiz.parse(t, "(nil A B)")
-        self.failUnless(not valid)
+        self.assertTrue(not valid)
 
 
     def testParseFlatTreeFails2(self):
         wiz = TreeWizard(self.adaptor, self.tokens)
         t = wiz.create("(nil A B C)")
         valid = wiz.parse(t, "(nil A B A)")
-        self.failUnless(not valid)
+        self.assertTrue(not valid)
 
 
     def testWildcard(self):
         wiz = TreeWizard(self.adaptor, self.tokens)
         t = wiz.create("(A B C)")
         valid = wiz.parse(t, "(A . .)")
-        self.failUnless(valid)
+        self.assertTrue(valid)
 
 
     def testParseWithText(self):
@@ -564,7 +564,7 @@ class TestTreeWizard(unittest.TestCase):
         # C pattern has no text arg so despite [bar] in t, no need
         # to match text--check structure only.
         valid = wiz.parse(t, "(A B[foo] C)")
-        self.failUnless(valid)
+        self.assertTrue(valid)
 
 
     def testParseWithText2(self):
@@ -580,7 +580,7 @@ class TestTreeWizard(unittest.TestCase):
         wiz = TreeWizard(self.adaptor, self.tokens)
         t = wiz.create("(A B C)")
         valid = wiz.parse(t, "(A[foo] B C)")
-        self.failUnless(not valid) # fails
+        self.assertTrue(not valid) # fails
 
 
     def testParseLabels(self):
@@ -588,10 +588,10 @@ class TestTreeWizard(unittest.TestCase):
         t = wiz.create("(A B C)")
         labels = {}
         valid = wiz.parse(t, "(%a:A %b:B %c:C)", labels)
-        self.failUnless(valid)
-        self.failUnlessEqual("A", str(labels["a"]))
-        self.failUnlessEqual("B", str(labels["b"]))
-        self.failUnlessEqual("C", str(labels["c"]))
+        self.assertTrue(valid)
+        self.assertEqual("A", str(labels["a"]))
+        self.assertEqual("B", str(labels["b"]))
+        self.assertEqual("C", str(labels["c"]))
 
 
     def testParseWithWildcardLabels(self):
@@ -599,9 +599,9 @@ class TestTreeWizard(unittest.TestCase):
         t = wiz.create("(A B C)")
         labels = {}
         valid = wiz.parse(t, "(A %b:. %c:.)", labels)
-        self.failUnless(valid)
-        self.failUnlessEqual("B", str(labels["b"]))
-        self.failUnlessEqual("C", str(labels["c"]))
+        self.assertTrue(valid)
+        self.assertEqual("B", str(labels["b"]))
+        self.assertEqual("C", str(labels["c"]))
 
 
     def testParseLabelsAndTestText(self):
@@ -609,10 +609,10 @@ class TestTreeWizard(unittest.TestCase):
         t = wiz.create("(A B[foo] C)")
         labels = {}
         valid = wiz.parse(t, "(%a:A %b:B[foo] %c:C)", labels)
-        self.failUnless(valid)
-        self.failUnlessEqual("A", str(labels["a"]))
-        self.failUnlessEqual("foo", str(labels["b"]))
-        self.failUnlessEqual("C", str(labels["c"]))
+        self.assertTrue(valid)
+        self.assertEqual("A", str(labels["a"]))
+        self.assertEqual("foo", str(labels["b"]))
+        self.assertEqual("C", str(labels["c"]))
 
 
     def testParseLabelsInNestedTree(self):
@@ -620,12 +620,12 @@ class TestTreeWizard(unittest.TestCase):
         t = wiz.create("(A (B C) (D E))")
         labels = {}
         valid = wiz.parse(t, "(%a:A (%b:B %c:C) (%d:D %e:E) )", labels)
-        self.failUnless(valid)
-        self.failUnlessEqual("A", str(labels["a"]))
-        self.failUnlessEqual("B", str(labels["b"]))
-        self.failUnlessEqual("C", str(labels["c"]))
-        self.failUnlessEqual("D", str(labels["d"]))
-        self.failUnlessEqual("E", str(labels["e"]))
+        self.assertTrue(valid)
+        self.assertEqual("A", str(labels["a"]))
+        self.assertEqual("B", str(labels["b"]))
+        self.assertEqual("C", str(labels["c"]))
+        self.assertEqual("D", str(labels["d"]))
+        self.assertEqual("E", str(labels["e"]))
 
 
     def testEquals(self):
@@ -633,7 +633,7 @@ class TestTreeWizard(unittest.TestCase):
         t1 = wiz.create("(A B C)")
         t2 = wiz.create("(A B C)")
         same = wiz.equals(t1, t2)
-        self.failUnless(same)
+        self.assertTrue(same)
 
 
     def testEqualsWithText(self):
@@ -641,7 +641,7 @@ class TestTreeWizard(unittest.TestCase):
         t1 = wiz.create("(A B[foo] C)")
         t2 = wiz.create("(A B[foo] C)")
         same = wiz.equals(t1, t2)
-        self.failUnless(same)
+        self.assertTrue(same)
 
 
     def testEqualsWithMismatchedText(self):
@@ -649,7 +649,7 @@ class TestTreeWizard(unittest.TestCase):
         t1 = wiz.create("(A B[foo] C)")
         t2 = wiz.create("(A B C)")
         same = wiz.equals(t1, t2)
-        self.failUnless(not same)
+        self.assertTrue(not same)
 
 
     def testEqualsWithMismatchedList(self):
@@ -657,7 +657,7 @@ class TestTreeWizard(unittest.TestCase):
         t1 = wiz.create("(A B C)")
         t2 = wiz.create("(A B A)")
         same = wiz.equals(t1, t2)
-        self.failUnless(not same)
+        self.assertTrue(not same)
 
 
     def testEqualsWithMismatchedListLength(self):
@@ -665,7 +665,7 @@ class TestTreeWizard(unittest.TestCase):
         t1 = wiz.create("(A B C)")
         t2 = wiz.create("(A B)")
         same = wiz.equals(t1, t2)
-        self.failUnless(not same)
+        self.assertTrue(not same)
 
 
     def testFindPattern(self):
@@ -674,7 +674,7 @@ class TestTreeWizard(unittest.TestCase):
         subtrees = wiz.find(t, "(A B)")
         found = [str(node) for node in subtrees]
         expecting = ['foo', 'big']
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
 
     def testFindTokenType(self):
@@ -683,7 +683,7 @@ class TestTreeWizard(unittest.TestCase):
         subtrees = wiz.find(t, wiz.getTokenType('A'))
         found = [str(node) for node in subtrees]
         expecting = ['A', 'foo', 'big']
-        self.failUnlessEqual(expecting, found)
+        self.assertEqual(expecting, found)
 
 
 

--- a/tool/src/main/resources/org/antlr/codegen/templates/Python/Python.stg
+++ b/tool/src/main/resources/org/antlr/codegen/templates/Python/Python.stg
@@ -291,7 +291,7 @@ class <grammar.recognizerName>(<@superClassName><superClass><@end>):
 
     <cyclicDFAs:cyclicDFA()> <! dump tables for all DFA !>
 
-    <bitsets:{it | FOLLOW_<it.name>_in_<it.inName><it.tokenIndex> = frozenset([<it.tokenTypes:{it | <it>};separator=", ">])<\n>}>
+    <bitsets:{it | FOLLOW_<tokenWorkaround(it.name)>_in_<it.inName><it.tokenIndex> = frozenset([<it.tokenTypes:{it | <it>};separator=", ">])<\n>}>
 
 >>
 
@@ -766,7 +766,7 @@ element(e) ::= <<
 
 /** match a token optionally with a label in front */
 tokenRef(token,label,elementIndex,terminalOptions={}) ::= <<
-<if(label)><label> = <endif>self.match(self.input, <token>, self.FOLLOW_<token>_in_<ruleName><elementIndex>)
+<if(label)><label> = <endif>self.match(self.input, <tokenWorkaround(token)>, self.FOLLOW_<tokenWorkaround(token)>_in_<ruleName><elementIndex>)
 >>
 
 /** ids+=ID */
@@ -800,7 +800,11 @@ self.matchRange(<a>, <b>)
 /** For now, sets are interval tests and must be tested inline */
 matchSet(s,label,elementIndex,postmatchCode="",terminalOptions={}) ::= <<
 <if(label)>
+<if(LEXER)>
+<label> = self.input.LA(1);<\n>
+<else>
 <label> = self.input.LT(1)<\n>
+<endif>
 <endif>
 if <s>:
     self.input.consume()
@@ -818,7 +822,7 @@ else:
     raise mse
 <else>
     raise mse
-    <! use following code to make it recover inline; remove throw mse;
+    <! use following code to make it recover inline; remove `raise mse`;
     self.recoverFromMismatchedSet(
         self.input, mse, self.FOLLOW_set_in_<ruleName><elementIndex>
         )
@@ -1071,7 +1075,7 @@ else:
 >>
 
 dfaEdgeSwitch(labels, targetState) ::= <<
-if <labels:{it | LA<decisionNumber> == <it>}; separator=" or ">:
+if <labels:{it | LA<decisionNumber> == <tokenWorkaround(it)>}; separator=" or ">:
     <targetState>
 >>
 
@@ -1476,6 +1480,15 @@ execForcedAction(action) ::= "<action>"
 // M I S C (properties, etc...)
 
 codeFileExtension() ::= ".py"
+
+tokenWorkaround(token) ::= <%
+<if(isInvalid.(token))>0<else><token><endif>
+%>
+
+isInvalid ::= [
+    "<INVALID>": true,
+    default: false
+]
 
 true_value() ::= "True"
 false_value() ::= "False"


### PR DESCRIPTION
Update the Python codegen target.  This is mostly about updating the `setup.py` with some URL tweaks, updating the unittests themselves to work with the `unittest` library included with python 2.7.13, and fixing some minor codegen issues that resulted in syntax errors in the output for a couple of the test cases.