### PR TITLE
Bazel support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ nb-configuration.xml
 
 # Python runtime files
 *.py[co]
+
+# Bazel
+bazel-bin
+bazel-out
+bazel-antlr3
+bazel-testlogs

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,29 @@
+"""BUILD.bazel file for ANTLR 3."""
+
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(default_visibility = ["//visibility:private"])
+
+java_library(
+    name = "java_runtime",
+    srcs = glob(
+        ["runtime/Java/src/main/java/**/*.java"],
+        # Avoid pulling in org.antlr.stringtemplate.
+        exclude = ["runtime/Java/src/main/java/org/antlr/runtime/tree/DOTTreeGenerator.java"],
+    ),
+    javacopts = [
+        "-Xep:EqualsHashCode:OFF",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "tool",
+    actual = "//tool/src:tool",
+    visibility = ["//visibility:public"],
+)
+
+test_suite(
+    name = "tests",
+    tests = ["//tool/src:tests"],
+)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,0 +1,29 @@
+workspace(name = "antlr3")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
+
+# This needs to be identical to the one used inhttps://github.com/antlr/stringtemplate4/blob/master/WORKSPACE.bazel.
+http_jar(
+    name = "antlr3_bootstrap",
+    sha256 = "46531814ba9739cdf20c6c1789c252d3d95b68932813d79fb8bbfdf8d5840417",
+    url = "http://www.antlr3.org/download/antlr-3.5.2-complete-no-st3.jar",
+)
+
+http_jar(
+    name = "junit",
+    sha256 = "8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3",
+    url = "https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar",
+)
+
+http_jar(
+    name = "hamcrest_core",
+    sha256 = "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
+    url = "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+)
+
+http_archive(
+    name = "stringtemplate4",
+    sha256 = "a91974e67013c1e68ef80794151dd66f04fc034cd3a9cf68af78867cd3067520",
+    strip_prefix = "stringtemplate4-139f34243e516fc9d2cc4db8eeaa825014d631cc",
+    url = "https://github.com/antlr/stringtemplate4/archive/139f34243e516fc9d2cc4db8eeaa825014d631cc.zip",
+)

--- a/contributors.txt
+++ b/contributors.txt
@@ -58,3 +58,4 @@ YYYY/MM/DD, github id, Full name, email
 2012/09/17, ksgokul, Gokulakannan Somasundaram, gokul007@gmail.com
 2012/11/22, sharwell, Sam Harwell, sam@tunnelvisionlabs.com
 2012/09/24, mike-lischke, Mike Lischke, mike@lischke-online.de
+2022/04/04, jcking, Justin King, jcking@google.com

--- a/runtime/Java/src/main/java/org/antlr/runtime/debug/DebugTreeAdaptor.java
+++ b/runtime/Java/src/main/java/org/antlr/runtime/debug/DebugTreeAdaptor.java
@@ -227,7 +227,7 @@ public class DebugTreeAdaptor implements TreeAdaptor {
 
 	@Override
 	public Object deleteChild(Object t, int i) {
-		return deleteChild(t, i);
+		return adaptor.deleteChild(t, i);
 	}
 
 	@Override

--- a/tool/src/BUILD.bazel
+++ b/tool/src/BUILD.bazel
@@ -1,0 +1,145 @@
+"""BUILD.bazel file for ANTLR 3."""
+
+load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_test")
+
+package(default_visibility = ["//visibility:private"])
+
+java_binary(
+    name = "tool",
+    main_class = "org.antlr.Tool",
+    visibility = ["//:__pkg__"],
+    runtime_deps = [":tool_lib"],
+)
+
+java_library(
+    name = "tool_lib",
+    srcs = glob(["main/java/**/*.java"]) + [
+        "main/java/org/antlr/grammar/v3/ANTLRLexer.java",
+        "main/java/org/antlr/grammar/v3/ANTLRParser.java",
+        "main/java/org/antlr/grammar/v3/ANTLRTreePrinter.java",
+        "main/java/org/antlr/grammar/v3/ANTLRv3Lexer.java",
+        "main/java/org/antlr/grammar/v3/ANTLRv3Parser.java",
+        "main/java/org/antlr/grammar/v3/ANTLRv3Tree.java",
+        "main/java/org/antlr/grammar/v3/ActionAnalysis.java",
+        "main/java/org/antlr/grammar/v3/ActionTranslator.java",
+        "main/java/org/antlr/grammar/v3/AssignTokenTypesWalker.java",
+        "main/java/org/antlr/grammar/v3/CodeGenTreeWalker.java",
+        "main/java/org/antlr/grammar/v3/DefineGrammarItemsWalker.java",
+        "main/java/org/antlr/grammar/v3/LeftRecursiveRuleWalker.java",
+        "main/java/org/antlr/grammar/v3/TreeToNFAConverter.java",
+    ],
+    javacopts = [
+        "-Xep:EqualsHashCode:OFF",
+    ],
+    resource_strip_prefix = "tool/src/main/resources",
+    resources = glob(["main/resources/**/*.stg"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":tool_bootstrap",
+        "//:java_runtime",
+        "@stringtemplate4",
+    ],
+)
+
+genrule(
+    name = "tool_bootstrap",
+    srcs = [
+        "main/antlr3/org/antlr/grammar/v3/ANTLR.g",
+        "main/antlr3/org/antlr/grammar/v3/ANTLRTreePrinter.g",
+        "main/antlr3/org/antlr/grammar/v3/ANTLRv3.g",
+        "main/antlr3/org/antlr/grammar/v3/ANTLRv3Tree.g",
+        "main/antlr3/org/antlr/grammar/v3/ActionAnalysis.g",
+        "main/antlr3/org/antlr/grammar/v3/ActionTranslator.g",
+        "main/antlr3/org/antlr/grammar/v3/AssignTokenTypesWalker.g",
+        "main/antlr3/org/antlr/grammar/v3/CodeGenTreeWalker.g",
+        "main/antlr3/org/antlr/grammar/v3/DefineGrammarItemsWalker.g",
+        "main/antlr3/org/antlr/grammar/v3/LeftRecursiveRuleWalker.g",
+        "main/antlr3/org/antlr/grammar/v3/TreeToNFAConverter.g",
+    ],
+    outs = [
+        "main/java/org/antlr/grammar/v3/ANTLRLexer.java",
+        "main/java/org/antlr/grammar/v3/ANTLRParser.java",
+        "main/java/org/antlr/grammar/v3/ANTLRTreePrinter.java",
+        "main/java/org/antlr/grammar/v3/ANTLRv3Lexer.java",
+        "main/java/org/antlr/grammar/v3/ANTLRv3Parser.java",
+        "main/java/org/antlr/grammar/v3/ANTLRv3Tree.java",
+        "main/java/org/antlr/grammar/v3/ActionAnalysis.java",
+        "main/java/org/antlr/grammar/v3/ActionTranslator.java",
+        "main/java/org/antlr/grammar/v3/AssignTokenTypesWalker.java",
+        "main/java/org/antlr/grammar/v3/CodeGenTreeWalker.java",
+        "main/java/org/antlr/grammar/v3/DefineGrammarItemsWalker.java",
+        "main/java/org/antlr/grammar/v3/LeftRecursiveRuleWalker.java",
+        "main/java/org/antlr/grammar/v3/TreeToNFAConverter.java",
+    ],
+    cmd = """
+      $(JAVA) -cp $(location @antlr3_bootstrap//jar) org.antlr.Tool -fo $(RULEDIR)/main/java/org/antlr/grammar/v3 $(location :main/antlr3/org/antlr/grammar/v3/ANTLR.g)
+      $(JAVA) -cp $(location @antlr3_bootstrap//jar) org.antlr.Tool -fo $(RULEDIR)/main/java/org/antlr/grammar/v3 $(location :main/antlr3/org/antlr/grammar/v3/ANTLRTreePrinter.g)
+      $(JAVA) -cp $(location @antlr3_bootstrap//jar) org.antlr.Tool -fo $(RULEDIR)/main/java/org/antlr/grammar/v3 $(location :main/antlr3/org/antlr/grammar/v3/ANTLRv3.g)
+      $(JAVA) -cp $(location @antlr3_bootstrap//jar) org.antlr.Tool -fo $(RULEDIR)/main/java/org/antlr/grammar/v3 $(location :main/antlr3/org/antlr/grammar/v3/ANTLRv3Tree.g)
+      $(JAVA) -cp $(location @antlr3_bootstrap//jar) org.antlr.Tool -fo $(RULEDIR)/main/java/org/antlr/grammar/v3 $(location :main/antlr3/org/antlr/grammar/v3/ActionAnalysis.g)
+      $(JAVA) -cp $(location @antlr3_bootstrap//jar) org.antlr.Tool -fo $(RULEDIR)/main/java/org/antlr/grammar/v3 $(location :main/antlr3/org/antlr/grammar/v3/ActionTranslator.g)
+      $(JAVA) -cp $(location @antlr3_bootstrap//jar) org.antlr.Tool -fo $(RULEDIR)/main/java/org/antlr/grammar/v3 $(location :main/antlr3/org/antlr/grammar/v3/AssignTokenTypesWalker.g)
+      $(JAVA) -cp $(location @antlr3_bootstrap//jar) org.antlr.Tool -fo $(RULEDIR)/main/java/org/antlr/grammar/v3 $(location :main/antlr3/org/antlr/grammar/v3/CodeGenTreeWalker.g)
+      $(JAVA) -cp $(location @antlr3_bootstrap//jar) org.antlr.Tool -fo $(RULEDIR)/main/java/org/antlr/grammar/v3 $(location :main/antlr3/org/antlr/grammar/v3/DefineGrammarItemsWalker.g)
+      $(JAVA) -cp $(location @antlr3_bootstrap//jar) org.antlr.Tool -fo $(RULEDIR)/main/java/org/antlr/grammar/v3 $(location :main/antlr3/org/antlr/grammar/v3/LeftRecursiveRuleWalker.g)
+      $(JAVA) -cp $(location @antlr3_bootstrap//jar) org.antlr.Tool -fo $(RULEDIR)/main/java/org/antlr/grammar/v3 $(location :main/antlr3/org/antlr/grammar/v3/TreeToNFAConverter.g)
+    """,
+    toolchains = ["@bazel_tools//tools/jdk:current_host_java_runtime"],
+    tools = ["@antlr3_bootstrap//jar"],
+)
+
+java_test(
+    name = "tests",
+    srcs = glob(["test/java/**/*.java"]),
+    args = [
+        "org.antlr.test.TestASTConstruction",
+        "org.antlr.test.TestAttributes",
+        "org.antlr.test.TestAutoAST",
+        "org.antlr.test.TestBufferedTreeNodeStream",
+        "org.antlr.test.TestCharDFAConversion",
+        "org.antlr.test.TestCommonTokenStream",
+        "org.antlr.test.TestCompositeGrammars",
+        "org.antlr.test.TestDFAConversion",
+        "org.antlr.test.TestDFAMatching",
+        "org.antlr.test.TestFastQueue",
+        "org.antlr.test.TestHeteroAST",
+        "org.antlr.test.TestInterpretedLexing",
+        "org.antlr.test.TestInterpretedParsing",
+        "org.antlr.test.TestIntervalSet",
+        "org.antlr.test.TestJavaCodeGeneration",
+        "org.antlr.test.TestLeftRecursion",
+        "org.antlr.test.TestLexer",
+        "org.antlr.test.TestMessages",
+        "org.antlr.test.TestNFAConstruction",
+        "org.antlr.test.TestRewriteAST",
+        "org.antlr.test.TestRewriteTemplates",
+        "org.antlr.test.TestSemanticPredicateEvaluation",
+        "org.antlr.test.TestSemanticPredicates",
+        "org.antlr.test.TestSets",
+        "org.antlr.test.TestSymbolDefinitions",
+        "org.antlr.test.TestSyntacticPredicateEvaluation",
+        "org.antlr.test.TestSyntaxErrors",
+        "org.antlr.test.TestTemplates",
+        "org.antlr.test.TestTokenRewriteStream",
+        "org.antlr.test.TestTopologicalSort",
+        "org.antlr.test.TestTreeGrammarRewriteAST",
+        "org.antlr.test.TestTreeIterator",
+        "org.antlr.test.TestTreeNodeStream",
+        "org.antlr.test.TestTreeParsing",
+        "org.antlr.test.TestTrees",
+        "org.antlr.test.TestTreeWizard",
+    ],
+    javacopts = [
+        "-Xep:JUnit4RunWithMissing:OFF",
+    ],
+    main_class = "org.junit.runner.JUnitCore",
+    use_testrunner = False,
+    visibility = ["//:__pkg__"],
+    deps = [
+        ":tool_lib",
+        "//:java_runtime",
+        "@hamcrest_core//jar",
+        "@junit//jar",
+        "@stringtemplate4",
+    ],
+)

--- a/tool/src/test/java/org/antlr/test/TestAutoAST.java
+++ b/tool/src/test/java/org/antlr/test/TestAutoAST.java
@@ -369,7 +369,7 @@ public class TestAutoAST extends BaseTest {
 
 	@Test
     public void testSetRootWithLabel() throws Exception {
-		
+
 		String grammar =
 			"grammar T;\n" +
 			"options {output=AST;}\n" +
@@ -807,7 +807,7 @@ public class TestAutoAST extends BaseTest {
 
 	// S U P P O R T
 
-	public void _test() throws Exception {
+	private void _test() throws Exception {
 		String grammar =
 			"grammar T;\n" +
 			"options {output=AST;}\n" +

--- a/tool/src/test/java/org/antlr/test/TestCharDFAConversion.java
+++ b/tool/src/test/java/org/antlr/test/TestCharDFAConversion.java
@@ -499,7 +499,7 @@ public class TestCharDFAConversion extends BaseTest {
 
 	// S U P P O R T
 
-	public void _template() throws Exception {
+	private void _template() throws Exception {
 		Grammar g = new Grammar(
 			"grammar T;\n"+
 			"a : A | B;");

--- a/tool/src/test/java/org/antlr/test/TestDFAConversion.java
+++ b/tool/src/test/java/org/antlr/test/TestDFAConversion.java
@@ -1524,7 +1524,7 @@ As a result, alternative(s) 2 were disabled for that input
 
 	// S U P P O R T
 
-	public void _template() throws Exception {
+	private void _template() throws Exception {
 		Grammar g = new Grammar(
 			"parser grammar t;\n"+
 			"a : A | B;");

--- a/tool/src/test/java/org/antlr/test/TestSemanticPredicateEvaluation.java
+++ b/tool/src/test/java/org/antlr/test/TestSemanticPredicateEvaluation.java
@@ -225,7 +225,7 @@ public class TestSemanticPredicateEvaluation extends BaseTest {
 
 	// S U P P O R T
 
-	public void _test() throws Exception {
+	private void _test() throws Exception {
 		String grammar =
 			"grammar T;\n" +
 			"options {output=AST;}\n" +

--- a/tool/src/test/java/org/antlr/test/TestSemanticPredicates.java
+++ b/tool/src/test/java/org/antlr/test/TestSemanticPredicates.java
@@ -185,7 +185,7 @@ public class TestSemanticPredicates extends BaseTest {
 			".s1-B->:s2=>1\n";
 		checkDecision(g, 1, expecting, new int[] {2},
 					  new int[] {1,2}, "A B", new int[] {1}, null, 3);
-	}	
+	}
 	 */
 
 	@Test public void testHoist2() throws Exception {
@@ -768,7 +768,7 @@ public class TestSemanticPredicates extends BaseTest {
 
 	// S U P P O R T
 
-	public void _template() throws Exception {
+	private void _template() throws Exception {
 		Grammar g = new Grammar(
 			"parser grammar t;\n"+
 			"a : A | B;");


### PR DESCRIPTION
Add initial Bazel support to ANTLR 3.

I still need to fix the tests, as Bazel executes in a different environment, and the tests are not sure how to find the dependencies required as they run in separate sub-processes.