### PR TITLE
prepare Reproducible Builds for ANTLR3

### DIFF
--- a/antlr-complete/pom.xml
+++ b/antlr-complete/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.0</version>
+                <version>3.3.0</version>
                 <configuration>
                     <minimizeJar>false</minimizeJar>
                     <createSourcesJar>true</createSourcesJar>

--- a/antlr3-maven-archetype/pom.xml
+++ b/antlr3-maven-archetype/pom.xml
@@ -29,7 +29,7 @@
       <extension>
         <groupId>org.apache.maven.archetype</groupId>
         <artifactId>archetype-packaging</artifactId>
-        <version>2.2</version>
+        <version>3.2.1</version>
       </extension>
 
     </extensions>
@@ -37,8 +37,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-archetype-plugin</artifactId>
-                <version>2.2</version>
-                <extensions>true</extensions>
+                <version>3.2.1</version>
             </plugin>
         </plugins>
 

--- a/antlr3-maven-plugin/pom.xml
+++ b/antlr3-maven-plugin/pom.xml
@@ -259,7 +259,7 @@ Jim Idle - March 2009
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.6.4</version>
             </plugin>
         </plugins>
     </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
     -->
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.build.outputTimestamp>10</project.build.outputTimestamp>
         <jdk>1.8</jdk>
         <junit.version>4.13</junit.version>
         <st4.version>4.3.1</st4.version>
@@ -223,7 +224,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.2.2</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -265,7 +266,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <!-- override the version inherited from the parent -->
-                <version>2.2.1</version>
+                <version>3.2.1</version>
             </plugin>
 
             <plugin>
@@ -302,6 +303,16 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-plugin-plugin</artifactId>
+                    <version>3.6.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>3.0.0-M6</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
see https://maven.apache.org/guides/mini/guide-reproducible-builds.html for more details on Reproducible Builds for Maven

with this PR merged, the build becomes near fully reproducible: there is only non-reproducible ANTLR3 output included

once #209 will be merged and released, you'll just have to update `antlr3-maven-plugin` version in `tools/pom.xml` that will fix the remaining non-reproducible bits for ANTLR3 itself

Notice: to check if your current ANTLR3 SNAPSHOT build is reproducible, just run:
```
mvn clean install artifact:check-buildplan -DskipTests -Psonatype-oss-release -Dgpg.skip -Dmaven.javadoc.skip
mvn clean verify artifact:compare -DskipTests -Psonatype-oss-release -Dgpg.skip -Dmaven.javadoc.skip
```

it will display at the end a summary of reproducibility