### PR TITLE
Support SOURCE_DATE_EPOCH for generatedTimestamp

### DIFF
--- a/tool/src/main/java/org/antlr/Tool.java
+++ b/tool/src/main/java/org/antlr/Tool.java
@@ -1052,6 +1052,9 @@ public class Tool {
      */
     public static String getCurrentTimeStamp() {
         GregorianCalendar calendar = new java.util.GregorianCalendar();
+        if (System.getenv("SOURCE_DATE_EPOCH") != null) {
+            calendar.setTimeInMillis(1000 * Long.parseLong(System.getenv("SOURCE_DATE_EPOCH")));
+        }
         int y = calendar.get(Calendar.YEAR);
         int m = calendar.get(Calendar.MONTH) + 1; // zero-based for months
         int d = calendar.get(Calendar.DAY_OF_MONTH);


### PR DESCRIPTION
antlr3 embeds a build timestamp in generated source code files. This allows overriding the timestamp using the SOURCE_DATE_EPOCH environment variable as defined at https://reproducible-builds.org/docs/source-date-epoch/. This allows users of antlr3 to eliminate a source of non-reproducibility in their builds.

This is an alternative to eliminating the timestamp as proposed in #209