### PR TITLE
ensure reproducible elements order by sorting

### DIFF
--- a/tool/src/main/antlr3/org/antlr/grammar/v3/CodeGenTreeWalker.g
+++ b/tool/src/main/antlr3/org/antlr/grammar/v3/CodeGenTreeWalker.g
@@ -56,6 +56,7 @@ import org.antlr.codegen.*;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.Collection;
+import java.util.Collections;
 import org.antlr.runtime.BitSet;
 import org.antlr.runtime.DFA;
 import org.stringtemplate.v4.ST;
@@ -284,6 +285,7 @@ protected final List<String> getTokenTypesAsTargetLabels(Collection<GrammarAST> 
         }
         labels.add( label );
     }
+	Collections.sort(labels); // ensure reproducible order
     return labels;
 }
 


### PR DESCRIPTION
extracted elements order non-controversial commit from #209 

fixes issues like:

```
├── org/antlr/grammar/v3/ANTLRv3Parser.java
│ @@ -427,15 +427,15 @@
│  				cnt7++;
│  			}
│
│  			EOF12=(Token)match(input,EOF,FOLLOW_EOF_in_grammarDef489); if (state.failed) return retval;
│  			if ( state.backtracking==0 ) stream_EOF.add(EOF12);
│
│  			// AST REWRITE
│ -			// elements: DOC_COMMENT, attrScope, optionsSpec, rule, tokensSpec, action, id
│ +			// elements: action, tokensSpec, attrScope, rule, optionsSpec, DOC_COMMENT, id
│  			// token labels:
│  			// rule labels: retval
│  			// token list labels:
│  			// rule list labels:
│  			// wildcard labels:
│  			if ( state.backtracking==0 ) {
│  			retval.tree = root_0;
```