### PR TITLE
Set up permissions for GitHub Workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,10 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    
+permissions:
+  contents: read
+  
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Closes #216 

## Changes
- Set `main.yml` top level permission to `contents: read`

## Test
I've tested and the workflow ran with success
https://github.com/joycebrum/antlr3/actions/runs/4246430550

